### PR TITLE
query size should not return result if query is too short

### DIFF
--- a/demo/autocomplete.py
+++ b/demo/autocomplete.py
@@ -23,13 +23,14 @@ class AutocompleteChoicesPages(AgnocompleteChoices):
 
 class AutocompleteChoicesPagesOverride(AutocompleteChoicesPages):
     page_size = 30
-    query_size = 21
-    query_size_min = 16
+    query_size = 6
+    query_size_min = 5
 
 
 class AutocompletePerson(AgnocompleteModel):
     model = Person
     fields = ['first_name', 'last_name']
+    query_size_min = 2
 
 
 # Special: not integrated into the registry (yet)
@@ -50,6 +51,7 @@ class AutocompletePersonDomain(AgnocompleteModel):
     fields = ['first_name', 'last_name']
     model = Person
     requires_authentication = True
+    query_size_min = 2
 
     def get_queryset(self):
         email = self.user.email

--- a/demo/tests/test_core.py
+++ b/demo/tests/test_core.py
@@ -24,10 +24,18 @@ from demo.models import Person
 from demo.tests import MockRequestUser
 
 
+# Should work with this query size
+@override_settings(
+    AGNOCOMPLETE_DEFAULT_QUERYSIZE=2,
+    AGNOCOMPLETE_MIN_QUERYSIZE=2,
+)
 class AutocompleteColorTest(TestCase):
     def test_items(self):
         instance = AutocompleteColor()
         self.assertEqual(list(instance.items()), [])
+        # Limit is 2, a 1-char-long query should be empty
+        self.assertEqual(list(instance.items(query='g')), [])
+        # Starting from 2 chars, it's okay
         self.assertEqual(
             list(instance.items(query='gr')), [
                 {'value': 'green', 'label': 'Green'},
@@ -155,6 +163,10 @@ class AutocompletePersonTest(TestCase):
         instance = AutocompletePerson()
         items = instance.items()
         self.assertEqual(len(items), 0)
+        # Limit is "2"
+        items = instance.items(query="a")
+        self.assertEqual(len(items), 0)
+        # Should be okay now
         items = instance.items(query="ali")
         self.assertEqual(len(items), 4)
         items = instance.items(query="bob")


### PR DESCRIPTION
refs #3, but not only.
