### PR TITLE
add a standard selector to fetch the agnocomplete-ready fields in the DOM

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ Changelog for django-agnocomplete
 master (unreleased)
 ==================
 
+Feature(s)
+----------
+
+- a more pertinent data attribute to target agnocomplete-ready fields (#22).
+
 Minor changes
 -------------
 

--- a/agnocomplete/constants.py
+++ b/agnocomplete/constants.py
@@ -16,3 +16,6 @@ AGNOCOMPLETE_DEFAULT_QUERYSIZE = 3
 
 "Agnocomplete minimum query size"
 AGNOCOMPLETE_MIN_QUERYSIZE = 2
+
+"Default data attribute name for fields"
+AGNOCOMPLETE_DATA_ATTRIBUTE = 'agnocomplete'

--- a/agnocomplete/widgets.py
+++ b/agnocomplete/widgets.py
@@ -4,8 +4,11 @@ Agnocomplete Widgets
 from django.forms import widgets
 from django.core.urlresolvers import reverse_lazy
 from django.utils.encoding import force_text as text
+from django.conf import settings
+
 
 from . import get_namespace
+from .constants import AGNOCOMPLETE_DATA_ATTRIBUTE
 
 __all__ = ['AgnocompleteInput']
 
@@ -23,9 +26,15 @@ class AgnocompleteWidgetMixin(object):
         )
         # Priority to the configurable URL
         data_url = self.agnocomplete.get_url() or data_url
+        # Data attribute
+        data_attribute = getattr(
+            settings, 'AGNOCOMPLETE_DATA_ATTRIBUTE',
+            AGNOCOMPLETE_DATA_ATTRIBUTE)
+        data_attribute = 'data-{}'.format(data_attribute)
         attrs.update({
             'data-url': data_url,
             'data-query-size': self.agnocomplete.get_query_size(),
+            data_attribute: 'on',
         })
         return attrs
 

--- a/demo/templates/selectize.html
+++ b/demo/templates/selectize.html
@@ -9,7 +9,7 @@
         <script src="{% static 'js/selectize.js' %}" charset="utf-8"></script>
         <script type="text/javascript">
         $(function() {
-            $('select').each(function(index, select) {
+            $('[data-agnocomplete]').each(function(index, select) {
                 $(select).selectize({
                     valueField: 'value',
                     labelField: 'label',

--- a/demo/tests/test_demo_views.py
+++ b/demo/tests/test_demo_views.py
@@ -1,5 +1,10 @@
 from django.test import TestCase
 from django.core.urlresolvers import reverse
+try:
+    from django.test import override_settings
+except ImportError:
+    # Django 1.6
+    from django.test.utils import override_settings
 
 from agnocomplete import get_namespace
 
@@ -21,6 +26,17 @@ class HomeTest(TestCase):
         attrs_color = search_color.widget.build_attrs()
         self.assertIn('data-url', attrs_color)
         self.assertIn('data-query-size', attrs_color)
+        self.assertIn('data-agnocomplete', attrs_color)
+
+    @override_settings(AGNOCOMPLETE_DATA_ATTRIBUTE='wow')
+    def test_data_attribute(self):
+        response = self.client.get(reverse('home'))
+        form = response.context['form']
+        search_color = form.fields['search_color']
+        attrs_color = search_color.widget.build_attrs()
+        self.assertIn('data-url', attrs_color)
+        self.assertIn('data-query-size', attrs_color)
+        self.assertIn('data-wow', attrs_color)
 
     def test_get(self):
         response = self.client.get(reverse('home'))

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -142,3 +142,43 @@ Alternatively, you can pass a full instance to your field definition, or a simpl
     person = fields.AgnocompleteModelField('AutocompletePerson')
 
 If the passed argument is the string or the class object, it'll be instanciated using its default parameters.
+
+
+The JS Side
+===========
+
+After that, the JS side is completely up to your integration choices. JQuery-based library, Vanilla JS, whichever suits you. You don't even have to use the custom fields provided, as long as you respect the API specs, you still can query it and use the results on your One-Page-App the way you want.
+
+Correct targetting
+------------------
+
+Let's imagine for a second that you're using a (fictional) JS lib name "wowcomplete". To add the autocomplete bit to a given control, all you need to do is:
+
+.. code-block:: js
+
+    $(document).ready(function() {
+        $('my-target-id-or-class').wowcomplete();
+    });
+
+The key point here is the target.
+
+* If you use: ``$('select')``, you may target select boxes that don't support agnocomplete AJAX queries,... And you may miss other inputs, like text boxes (jquery-autocomplete doesn't use selects, for example),
+* If you use ``$('select[data-url]')``? It could work also. The only problem here is if you have other select boxes using the same ``data-url`` attribute.
+
+To handle this we've added a ``data-agnocomplete`` data attribute. If this attribute is present, there's a 100% chances that your input is agnocomplete-ready.
+
+As a consequence, the standard way to target your inputs is:
+
+.. code-block:: js
+
+    $(document).ready(function() {
+        $('[data-agnocomplete]').wowcomplete();
+    });
+
+Of course, if you want to use a different attribute, you can override it using the following settings:
+
+.. code-block:: python
+
+    AGNOCOMPLETE_DATA_ATTRIBUTE = 'wowcomplete'
+
+This settings will add a ``data-wowcomplete`` attribute to all your agnocomplete-ready fields.


### PR DESCRIPTION
rather than fetching elements that have a "data-url" attribute, add an arbitrary css class selector (e.g. `data-agnocomplete`). Usage example:

``` js
$('[data-agnocomplete]').selectize(/* ... */)
```
