### PR TITLE
make docs should be a phony target

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ master (unreleased)
 ===================
 
 - Add a new method to have the possibilty to override easily the display label (#34).
+- ``make docs`` is a PHONY makefile target.
 
 0.2.0 (2015-09-17)
 ==================

--- a/Makefile
+++ b/Makefile
@@ -17,5 +17,6 @@ test:
 serve:
 	tox -e serve
 
+.PHONY: docs
 docs:
 	tox -e docs


### PR DESCRIPTION
in order to prevent the "docs is already up to date", while it's not
