### PR TITLE
Improving performances by slicing resultset before rendering

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog for django-agnocomplete
 0.3.0 (unreleased)
 ==================
 
+- Improve performances by slicing the resultset before rendering (#36).
 - Added an `item(current_item)` method to override display label on choices (#37).
 
 

--- a/agnocomplete/core.py
+++ b/agnocomplete/core.py
@@ -247,8 +247,9 @@ class AgnocompleteChoices(AgnocompleteBase):
             result = filter(lambda x: x[1].lower().startswith(query), result)
             result = tuple(result)
 
-        result = [self.item(item) for item in result]
-        return result[:self.get_page_size()]
+        # Slicing before rendering
+        result = result[:self.get_page_size()]
+        return [self.item(item) for item in result]
 
     def selected(self, ids):
         """
@@ -350,9 +351,9 @@ class AgnocompleteModel(AgnocompleteModelBase):
 
     def serialize(self, queryset):
         result = []
-        for item in queryset:
+        for item in queryset[:self.get_page_size()]:
             result.append(self.item(item))
-        return result[:self.get_page_size()]
+        return result
 
     def item(self, current_item):
         """

--- a/demo/tests/test_core.py
+++ b/demo/tests/test_core.py
@@ -333,3 +333,39 @@ class AgnoCompleteAbstractMethod(TestCase):
             """Can't instantiate abstract class WickedAgnocompleteBase\
  with abstract methods get_choices, items, selected"""
         )
+
+
+class CountItemCalls(object):
+    query_size = 1
+    query_size_min = 1
+
+    def __init__(self, *args, **kwargs):
+        super(CountItemCalls, self).__init__(*args, **kwargs)
+        self._count_item_calls = 0
+
+    def item(self, current_item):
+        self._count_item_calls += 1
+        return super(CountItemCalls, self).item(current_item)
+
+
+class AutocompletePersonPerformance(CountItemCalls, AutocompletePerson):
+    pass
+
+
+class AutocompleteColorPerformance(CountItemCalls, AutocompleteColor):
+    pass
+
+
+class PerformanceTest(TestCase):
+
+    def test_item_calls_core(self):
+        instance = AutocompleteColorPerformance(page_size=2)
+        items = instance.items(query='gr')
+        self.assertEqual(len(items), 2)
+        self.assertEqual(instance._count_item_calls, 2)
+
+    def test_item_calls_model(self):
+        instance = AutocompletePersonPerformance(page_size=2)
+        items = instance.items(query="ali")
+        self.assertEqual(len(items), 2)
+        self.assertEqual(instance._count_item_calls, 2)


### PR DESCRIPTION
This would avoid a costly "item()" method to be called too many times (more than the actual result count)
