### PR TITLE
Python 3.5.0 is out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+python:
+  - "3.5"
 script: tox
 install:
-    - pip install tox
+  - pip install tox

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for django-agnocomplete
 master (unreleased)
 ===================
 
-- Nothing changed yet.
+- Now ready for Python 3.5. (#19) - Note: Only available for Django 1.8 and above.
 
 
 0.4.0 (2016-02-04)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,33,34}-django{16,17,18},flake8
+envlist = py{27,33,34,35}-django{16,17,18},flake8
 
 [testenv]
 usedevelop = True
@@ -8,6 +8,7 @@ basepython =
     py27: python2.7
     py33: python3.3
     py34: python3.4
+    py35: python3.5
     flake8: python2.7
     serve: python2.7
     serve16: python2.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,33,34,35}-django{16,17,18},flake8
+envlist = py{27,33,34}-django{16,17,18},flake8,py35-django18
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
add a 3.5 job in travis grid.

note: Django 1.7 and below are not compatible with Python 3.5
