### PR TITLE
Allow extra context to be passed via GET arguments and eventually picked up by search methods

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ master (unreleased)
 
 - Dropped support for Django 1.6 / 1.7 (#54),
 - Added support for Django 1.9. Please note that the combination Python 3.3 and Django 1.9 is incompatible - `see Django 1.9 release notes <https://docs.djangoproject.com/en/1.10/releases/1.9/>`_ (#56).
+- Added support for extra arguments passed to the search URL, passed on the Agnocomplete class (#52).
 
 
 0.5.0 (2016-07-01)

--- a/agnocomplete/core.py
+++ b/agnocomplete/core.py
@@ -396,7 +396,22 @@ class AgnocompleteModel(AgnocompleteModelBase):
             'label': text(current_item)
         }
 
-    def build_filtered_queryset(self, query):
+    def build_extra_filtered_queryset(self, queryset, **kwargs):
+        """
+        Apply eventual queryset filters, based on the optional extra arguments
+        passed to the query.
+
+        By default, this method returns the queryset "verbatim". You can
+        override or overwrite this to perform custom filter on this QS.
+
+        * `queryset`: it's the final queryset build using the search terms.
+        * `kwargs`: this dictionary contains the extra arguments passed to the
+          agnocomplete class.
+        """
+        # By default, we're ignoring these arguments and return verbatim QS
+        return queryset
+
+    def build_filtered_queryset(self, query, **kwargs):
         """
         Build and return the fully-filtered queryset
         """
@@ -404,7 +419,7 @@ class AgnocompleteModel(AgnocompleteModelBase):
         qs = self.get_queryset()
         # filter it via the query conditions
         qs = qs.filter(self.get_queryset_filters(query))
-        return qs
+        return self.build_extra_filtered_queryset(qs, **kwargs)
 
     def items(self, query=None, **kwargs):
         """
@@ -429,7 +444,7 @@ class AgnocompleteModel(AgnocompleteModelBase):
                     "Authentication is required to use this autocomplete"
                 )
 
-        qs = self.build_filtered_queryset(query)
+        qs = self.build_filtered_queryset(query, **kwargs)
         # The final queryset is the paginated queryset
         self.__final_queryset = qs
         return self.serialize(qs)

--- a/agnocomplete/core.py
+++ b/agnocomplete/core.py
@@ -202,7 +202,7 @@ class AgnocompleteBase(with_metaclass(ABCMeta, object)):
         pass
 
     @abstractmethod
-    def items(self, query=None):
+    def items(self, query=None, **kwargs):
         pass
 
     @abstractmethod
@@ -234,7 +234,7 @@ class AgnocompleteChoices(AgnocompleteBase):
         value, label = current_item
         return dict(value=value, label=label)
 
-    def items(self, query=None):
+    def items(self, query=None, **kwargs):
         # No query, no item
         if not query:
             return []
@@ -406,7 +406,7 @@ class AgnocompleteModel(AgnocompleteModelBase):
         qs = qs.filter(self.get_queryset_filters(query))
         return qs
 
-    def items(self, query=None):
+    def items(self, query=None, **kwargs):
         """
         Return the items to be sent to the client
         """

--- a/agnocomplete/views.py
+++ b/agnocomplete/views.py
@@ -37,12 +37,16 @@ class AgnocompleteJSONView(with_metaclass(ABCMeta, View)):
             return "text/html"
 
     @abstractmethod
-    def get_dataset(self):
+    def get_dataset(self, **kwargs):
         pass
+
+    def get_extra_arguments(self):
+        extra = filter(lambda x: x[0] != 'q', self.request.GET.items())
+        return dict(extra)
 
     def get(self, *args, **kwargs):
         return JsonResponse(
-            {'data': self.get_dataset()},
+            {'data': self.get_dataset(**self.get_extra_arguments())},
             content_type=self.content_type,
         )
 
@@ -92,7 +96,7 @@ class CatalogView(RegistryMixin, AgnocompleteJSONView):
     The catalog view displays every available Agnocomplete slug available in
     the registry.
     """
-    def get_dataset(self):
+    def get_dataset(self, **kwargs):
         """
         Return the registry key set.
         """
@@ -109,7 +113,7 @@ class AgnocompleteGenericView(AgnocompleteJSONView):
             return self.klass
         raise ImproperlyConfiguredView("Undefined autocomplete class")
 
-    def get_dataset(self):
+    def get_dataset(self, **kwargs):
         klass = self.get_klass()
         # Query passed via the argument
         query = self.request.GET.get('q', "")
@@ -126,7 +130,7 @@ class AgnocompleteGenericView(AgnocompleteJSONView):
         # Agnocomplete instance is ready
         try:
             instance = klass(user=self.request.user, page_size=page_size)
-            return instance.items(query=query)
+            return instance.items(query=query, **self.get_extra_arguments())
         except AuthenticationRequiredAgnocompleteException:
             raise PermissionDenied(
                 "Unauthorized access to this Autocomplete")

--- a/agnocomplete/views.py
+++ b/agnocomplete/views.py
@@ -130,7 +130,7 @@ class AgnocompleteGenericView(AgnocompleteJSONView):
         # Agnocomplete instance is ready
         try:
             instance = klass(user=self.request.user, page_size=page_size)
-            return instance.items(query=query, **self.get_extra_arguments())
+            return instance.items(query=query, **kwargs)
         except AuthenticationRequiredAgnocompleteException:
             raise PermissionDenied(
                 "Unauthorized access to this Autocomplete")

--- a/demo/autocomplete.py
+++ b/demo/autocomplete.py
@@ -51,6 +51,16 @@ class AutocompletePerson(AgnocompleteModel):
     query_size_min = 2
 
 
+class AutocompletePersonExtra(AutocompletePerson):
+
+    def build_extra_filtered_queryset(self, queryset, **kwargs):
+        # Filtering on location if provided
+        location = kwargs.get('extra_argument', None)
+        if location:
+            queryset = queryset.filter(location__iexact=location)
+        return queryset
+
+
 class AutocompletePersonShort(AutocompletePerson):
     query_size = 2
 
@@ -134,6 +144,7 @@ register(AutocompleteColor)
 register(AutocompleteColorExtra)
 register(AutocompleteColorShort)
 register(AutocompletePerson)
+register(AutocompletePersonExtra)
 register(AutocompletePersonShort)
 register(AutocompleteChoicesPages)
 register(AutocompleteChoicesPagesOverride)

--- a/demo/autocomplete.py
+++ b/demo/autocomplete.py
@@ -14,6 +14,16 @@ class AutocompleteColor(AgnocompleteChoices):
     choices = COLORS
 
 
+class AutocompleteColorExtra(AutocompleteColor):
+    def items(self, query, **kwargs):
+        extra_argument = kwargs.get('extra_argument', None)
+        result = super(AutocompleteColorExtra, self).items(query, **kwargs)
+        # This is a very dummy usage of the extra argument
+        if extra_argument:
+            result.append({'value': 'EXTRA', 'label': 'EXTRA'})
+        return result
+
+
 class AutocompleteColorShort(AutocompleteColor):
     query_size = 2
     query_size_min = 2
@@ -121,6 +131,7 @@ class AutocompleteContextTag(AgnocompleteModel):
 
 # Registration
 register(AutocompleteColor)
+register(AutocompleteColorExtra)
 register(AutocompleteColorShort)
 register(AutocompletePerson)
 register(AutocompletePersonShort)

--- a/demo/fixtures/initial_data.yaml
+++ b/demo/fixtures/initial_data.yaml
@@ -4,6 +4,7 @@
     first_name: Alice
     last_name: Iñtërnâtiônàlizætiøn
     email: alice@example.com
+    location: Paris
 
 - model: demo.person
   pk: 2
@@ -11,6 +12,7 @@
     first_name: Alice
     last_name: Inchains
     email: alice2@example.com
+    location: Marseille
 
 - model: demo.person
   pk: 3
@@ -18,6 +20,7 @@
     first_name: Bob
     last_name: Hope
     email: bob@demo.com
+    location: Paris
 
 - model: demo.person
   pk: 4
@@ -25,6 +28,7 @@
     first_name: Alice
     last_name: Obvious
     email: alice3@example.com
+    location: Marseille
 
 - model: demo.person
   pk: 5
@@ -32,6 +36,7 @@
     first_name: Alice
     last_name: Galactic
     email: alice4@example.com
+    location: Berlin
 
 - model: demo.person
   pk: 6
@@ -39,6 +44,7 @@
     first_name: Luke
     last_name: Skywalker
     email: luke@example.com
+    location: Tatooine
 
 # Tags
 - model: demo.tag

--- a/demo/forms.py
+++ b/demo/forms.py
@@ -12,6 +12,7 @@ from .autocomplete import (
     AutocompleteColorExtra,
     AutocompleteColorShort,
     AutocompletePerson,
+    AutocompletePersonExtra,
     AutocompletePersonShort,
     HiddenAutocomplete,
     AutocompleteTag,
@@ -26,8 +27,10 @@ class SearchForm(forms.Form):
     search_person = fields.AgnocompleteModelField(AutocompletePerson)
 
 
-class SearchFormExtra(SearchForm):
+class SearchFormExtra(forms.Form):
     search_color = fields.AgnocompleteField(AutocompleteColorExtra)
+    search_person = fields.AgnocompleteModelField(AutocompletePersonExtra)
+    extra_argument = forms.CharField(required=False)
 
 
 class SearchFormTextInput(forms.Form):

--- a/demo/forms.py
+++ b/demo/forms.py
@@ -9,6 +9,7 @@ from agnocomplete.forms import UserContextFormMixin
 
 from .autocomplete import (
     AutocompleteColor,
+    AutocompleteColorExtra,
     AutocompleteColorShort,
     AutocompletePerson,
     AutocompletePersonShort,
@@ -23,6 +24,10 @@ from .fields import ModelMultipleDomainField
 class SearchForm(forms.Form):
     search_color = fields.AgnocompleteField(AutocompleteColor)
     search_person = fields.AgnocompleteModelField(AutocompletePerson)
+
+
+class SearchFormExtra(SearchForm):
+    search_color = fields.AgnocompleteField(AutocompleteColorExtra)
 
 
 class SearchFormTextInput(forms.Form):

--- a/demo/models.py
+++ b/demo/models.py
@@ -6,6 +6,7 @@ class Person(models.Model):
     first_name = models.CharField(max_length=100)
     last_name = models.CharField(max_length=100)
     email = models.EmailField(max_length=100)
+    location = models.CharField(max_length=100)
 
     def __unicode__(self):
         return " ".join((self.first_name, self.last_name))

--- a/demo/static/js/demo/selectize-extra.js
+++ b/demo/static/js/demo/selectize-extra.js
@@ -22,7 +22,7 @@ $(document).ready(function() {
                     return callback();
                 // Query's ready
                 $.ajax({
-                    url: $(select).data('url') + '?q=' + encodeURIComponent(query) + '&extra_argument=' + encodeURIComponent("hello I'm the extra argument"),
+                    url: $(select).data('url') + '?q=' + encodeURIComponent(query) + '&extra_argument=' + encodeURIComponent($("#id_extra_argument").val()),
                     type: 'GET',
                     error: function() {
                         callback();

--- a/demo/static/js/demo/selectize-extra.js
+++ b/demo/static/js/demo/selectize-extra.js
@@ -1,0 +1,37 @@
+$(document).ready(function() {
+    $('[data-agnocomplete]').each(function(index, select) {
+
+        function getMaxItems() {
+            var multi = $(select).attr('multiple') || false;
+            if (multi) {
+                // null means no limit to maxItems
+                return null;
+            }
+            return 1;
+        }
+
+        $(select).selectize({
+            valueField: 'value',
+            labelField: 'label',
+            searchField: 'label',
+            maxItems: getMaxItems(),
+            create: Boolean($(select).data('create')),
+            load: function(query, callback) {
+                // Using the query size limit to avoid querying too soon.
+                if (query.length < $(select).data('query-size'))
+                    return callback();
+                // Query's ready
+                $.ajax({
+                    url: $(select).data('url') + '?q=' + encodeURIComponent(query) + '&extra_argument=' + encodeURIComponent("hello I'm the extra argument"),
+                    type: 'GET',
+                    error: function() {
+                        callback();
+                    },
+                    success: function(res) {
+                        callback(res.data);
+                    }
+                });
+            }
+        });
+    });
+});

--- a/demo/templates/includes/nav.html
+++ b/demo/templates/includes/nav.html
@@ -3,6 +3,7 @@ Demo pages:
     <li><a href="{% url 'home' %}">Index</a></li>
     <li><a href="{% url 'filled-form' %}">Filled form</a></li>
     <li><a href="{% url 'selectize' %}">[JS DEMO] Selectize</a></li>
+    <li><a href="{% url 'selectize-extra' %}">[JS DEMO] Selectize with extra argument in query payload</a></li>
     <li><a href="{% url 'selectize-multi' %}">[JS DEMO] Selectize w/ multi-selection</a></li>
     <li><a href="{% url 'select2' %}">[JS DEMO] Select2</a></li>
     <li><a href="{% url 'jquery-autocomplete' %}">[JS DEMO] JQuery Autocomplete</a></li>

--- a/demo/templates/selectize.html
+++ b/demo/templates/selectize.html
@@ -7,5 +7,9 @@
 {% block extra_body %}
         <script src="{% static 'js/jquery.js' %}" charset="utf-8"></script>
         <script src="{% static 'js/selectize.js' %}" charset="utf-8"></script>
+        {% if selectize_with_extra %}
+        <script src="{% static 'js/demo/selectize-extra.js' %}" charset="utf-8"></script>
+        {% else %}
         <script src="{% static 'js/demo/selectize.js' %}" charset="utf-8"></script>
+        {% endif %}
 {% endblock %}

--- a/demo/tests/__init__.py
+++ b/demo/tests/__init__.py
@@ -13,10 +13,11 @@ class LoaddataTestCase(TestCase):
 class RegistryTestGeneric(LoaddataTestCase):
 
     def _test_registry_keys(self, keys):
-        self.assertEqual(len(keys), 11)
+        self.assertEqual(len(keys), 12)
         self.assertIn("AutocompleteColor", keys)
         self.assertIn("AutocompleteColorExtra", keys)
         self.assertIn("AutocompletePerson", keys)
+        self.assertIn("AutocompletePersonExtra", keys)
         self.assertIn("AutocompletePersonShort", keys)
         self.assertIn("AutocompleteChoicesPages", keys)
         self.assertIn("AutocompleteChoicesPagesOverride", keys)

--- a/demo/tests/__init__.py
+++ b/demo/tests/__init__.py
@@ -13,8 +13,9 @@ class LoaddataTestCase(TestCase):
 class RegistryTestGeneric(LoaddataTestCase):
 
     def _test_registry_keys(self, keys):
-        self.assertEqual(len(keys), 10)
+        self.assertEqual(len(keys), 11)
         self.assertIn("AutocompleteColor", keys)
+        self.assertIn("AutocompleteColorExtra", keys)
         self.assertIn("AutocompletePerson", keys)
         self.assertIn("AutocompletePersonShort", keys)
         self.assertIn("AutocompleteChoicesPages", keys)

--- a/demo/tests/test_demo_views.py
+++ b/demo/tests/test_demo_views.py
@@ -195,6 +195,10 @@ class JSDemoViews(TestCase):
         response = self.client.get(reverse('selectize'))
         self.assertEqual(response.status_code, 200)
 
+    def test_selectize_extra(self):
+        response = self.client.get(reverse('selectize-extra'))
+        self.assertEqual(response.status_code, 200)
+
     def test_selectize_multi(self):
         response = self.client.get(reverse('selectize-multi'))
         self.assertEqual(response.status_code, 200)
@@ -473,3 +477,59 @@ class ContextTagTestCase(MultipleModelSelectGeneric):
         self.assertIn("hello", names)
         self.assertIn("newtag1", names)
         self.assertEqual(("example.com", "example.com"), domains)
+
+
+class SelectizeExtraTest(TestCase):
+
+    def setUp(self):
+        super(SelectizeExtraTest, self).setUp()
+        self.search_url = get_namespace() + ':agnocomplete'
+
+    def test_context(self):
+        response = self.client.get(reverse('selectize-extra'))
+        # Variable set with context_data
+        self.assertIn('selectize_with_extra', response.context)
+        # Loaded the alternate JS
+        self.assertContains(response, "selectize-extra.js")
+
+    def test_no_extra_arg_normal(self):
+        # Using the normal color search. no extra.
+        response = self.client.get(
+            reverse(self.search_url, args=['AutocompleteColor']),
+            data={'q': "green"}
+        )
+        result = json.loads(response.content.decode())
+        data = result.get('data')
+        self.assertEqual(len(data), 1)
+
+    def test_extra_arg_normal(self):
+        # Using the normal color search. extra arg. no problem.
+        response = self.client.get(
+            reverse(self.search_url, args=['AutocompleteColor']),
+            data={'q': "green", "extra_argument": "Hello I'm here"}
+        )
+        result = json.loads(response.content.decode())
+        # No extra stuff, this view doesn't use these extra arguments
+        data = result.get('data')
+        self.assertEqual(len(data), 1)
+
+    def test_no_extra_arg_extra(self):
+        response = self.client.get(
+            reverse(self.search_url, args=['AutocompleteColorExtra']),
+            data={'q': "green"}
+        )
+        result = json.loads(response.content.decode())
+        data = result.get('data')
+        self.assertEqual(len(data), 1)
+
+    def test_extra_arg(self):
+        search_url = get_namespace() + ':agnocomplete'
+        response = self.client.get(
+            reverse(search_url, args=['AutocompleteColorExtra']),
+            data={'q': "green", "extra_argument": "Hello I'm here"}
+        )
+        result = json.loads(response.content.decode())
+        data = result.get('data')
+        self.assertEqual(len(data), 2)
+        added = data[-1]
+        self.assertEqual(added, {'value': 'EXTRA', 'label': 'EXTRA'})

--- a/demo/tests/test_demo_views.py
+++ b/demo/tests/test_demo_views.py
@@ -479,7 +479,7 @@ class ContextTagTestCase(MultipleModelSelectGeneric):
         self.assertEqual(("example.com", "example.com"), domains)
 
 
-class SelectizeExtraTest(TestCase):
+class SelectizeExtraTest(LoaddataTestCase):
 
     def setUp(self):
         super(SelectizeExtraTest, self).setUp()
@@ -533,3 +533,44 @@ class SelectizeExtraTest(TestCase):
         self.assertEqual(len(data), 2)
         added = data[-1]
         self.assertEqual(added, {'value': 'EXTRA', 'label': 'EXTRA'})
+
+    def test_model_no_extra_arg_normal(self):
+        # Using the normal color search. no extra.
+        response = self.client.get(
+            reverse(self.search_url, args=['AutocompletePerson']),
+            data={'q': "Alice"}
+        )
+        result = json.loads(response.content.decode())
+        data = result.get('data')
+        self.assertEqual(len(data), 4)
+
+    def test_model_extra_arg_normal(self):
+        # Using the normal color search. extra arg. no problem.
+        response = self.client.get(
+            reverse(self.search_url, args=['AutocompletePerson']),
+            data={'q': "Alice", "extra_argument": "Hello I'm here"}
+        )
+        result = json.loads(response.content.decode())
+        # No extra stuff, this view doesn't use these extra arguments
+        data = result.get('data')
+        self.assertEqual(len(data), 4)
+
+    def test_model_no_extra_arg_extra(self):
+        response = self.client.get(
+            reverse(self.search_url, args=['AutocompletePersonExtra']),
+            data={'q': "Alice"}
+        )
+        result = json.loads(response.content.decode())
+        data = result.get('data')
+        self.assertEqual(len(data), 4)
+
+    def test_model_extra_arg(self):
+        search_url = get_namespace() + ':agnocomplete'
+        response = self.client.get(
+            reverse(search_url, args=['AutocompletePersonExtra']),
+            data={'q': "Alice", "extra_argument": "Marseille"}
+        )
+        # Only the "Alices" that live in Marseille
+        result = json.loads(response.content.decode())
+        data = result.get('data')
+        self.assertEqual(len(data), 2)

--- a/demo/urls.py
+++ b/demo/urls.py
@@ -30,6 +30,7 @@ urlpatterns = [
     url(r'^custom/$', 'demo.views.search_custom', name='search-custom'),
     # Demo Front JS views
     url(r'^selectize/$', 'demo.views.selectize', name='selectize'),
+    url(r'^selectize-extra/$', 'demo.views.selectize_extra', name='selectize-extra'),  # noqa
     url(r'^selectize-multi/$', 'demo.views.selectize_multi', name='selectize-multi'),  # noqa
     url(r'^selectize-tag/$', 'demo.views.selectize_tag', name='selectize-tag'),
     url(r'^selectize-model-tag/$', 'demo.views.selectize_model_tag', name='selectize-model-tag'),  # noqa

--- a/demo/views.py
+++ b/demo/views.py
@@ -12,7 +12,7 @@ from agnocomplete.views import (
 from agnocomplete.decorators import allow_create
 
 from .forms import (
-    SearchForm, SearchContextForm, SearchCustom,
+    SearchForm, SearchFormExtra, SearchContextForm, SearchCustom,
     SearchFormTextInput, SearchColorMulti,
     PersonTagForm, PersonTagModelForm,
     PersonTagModelFormWithCreate,
@@ -83,6 +83,19 @@ class HiddenAutocompleteView(AgnocompleteGenericView):
 class SelectizeView(AutoView):
     template_name = 'selectize.html'
     title = "View using the Selectize autocomplete front library"
+
+
+class SelectizeExtraView(AutoView):
+    template_name = 'selectize.html'
+    title = "View using the Selectize autocomplete front library" \
+        " + extra arguments"
+    form_class = SearchFormExtra
+
+    def get_context_data(self, *args, **kwargs):
+        data = super(SelectizeExtraView, self).get_context_data(
+            *args, **kwargs)
+        data['selectize_with_extra'] = 'yes'
+        return data
 
 
 class SelectizeMultiView(AutoView):
@@ -166,6 +179,7 @@ search_custom = SearchCustomView.as_view()
 hidden_autocomplete = HiddenAutocompleteView.as_view()
 # JS Demo views
 selectize = SelectizeView.as_view()
+selectize_extra = SelectizeExtraView.as_view()
 selectize_multi = SelectizeMultiView.as_view()
 select2 = Select2View.as_view()
 jquery_autocomplete = JqueryAutocompleteView.as_view()

--- a/docs/autocomplete-definition.rst
+++ b/docs/autocomplete-definition.rst
@@ -227,7 +227,7 @@ You may want to add extra fields to your returned records, fields that belong to
         queryset = queryset[:2]
 
 Extra arguments
----------------
+===============
 
 Your front-end code may send you extra arguments that are not covered by the standard interface definition. These arguments will be passed down to your ``Agnocomplete`` class and can be used in the :meth:`items()` or the :meth:`get_dataset()` methods.
 
@@ -240,7 +240,7 @@ Your front-end code may send you extra arguments that are not covered by the sta
                 change_something_in_the_search_method(extra_stuff)
             return super(AutocompleteColorExtra, self).items(query, **kwargs)
 
-You can also override the :meth:`get_extra_arguments()` method **in your views** to eventually filter or manipulate these extra arguments.
+You can also override the :meth:`get_extra_arguments()` method **in your views** to eventually filter or manipulate these extra arguments. By default, :meth:`get_extra_arguments()` grabs arguments from the GET parameters that are not the `query` value.
 
 .. code-block:: python
 
@@ -253,12 +253,18 @@ You can also override the :meth:`get_extra_arguments()` method **in your views**
             extras = super(SelectizeExtraView, self).get_extra_arguments()
             whitelist = ['foo', 'bar']
             extras = filter(lambda x: x[0] in whitelist, extras)
-            return extras
+            return dict(extras)
 
-In the case of a queryset-based Agnocomplete, you can also use the extra arguments in the ``Agnocomplete`` class.
+Everything is possible in the view: you can even push your custom arguments, based on your current context, the date/time, etc.
+
+.. important::
+
+    The result of this method must be a dictionary.
 
 Using Extra arguments with Models/Querysets
-+++++++++++++++++++++++++++++++++++++++++++
+-------------------------------------------
+
+In the case of a queryset-based Agnocomplete, you can also use the extra arguments in the ``Agnocomplete`` class.
 
 The extra arguments are passed along to :meth:`items()`, and then to the :meth:`build_filtered_queryset()` method.
 

--- a/docs/autocomplete-definition.rst
+++ b/docs/autocomplete-definition.rst
@@ -225,3 +225,36 @@ You may want to add extra fields to your returned records, fields that belong to
 
         queryset = self.final_raw_queryset.filter(field="something")
         queryset = queryset[:2]
+
+Extra arguments
+---------------
+
+Your front-end code may send you extra arguments that are not covered by the standard interface definition. These arguments will be passed down to your ``Agnocomplete`` class and can be used in the :meth:`items()` or the :meth:`get_dataset()` methods.
+
+.. code-block:: python
+
+    class AutocompleteColorExtra(AutocompleteColor):
+        def items(self, query, **kwargs):
+            extra = kwargs.get('extra_suff', None)
+            if extra_stuff:
+                change_something_in_the_search_method(extra_stuff)
+            return super(AutocompleteColorExtra, self).items(query, **kwargs)
+
+You can also override the :meth:`get_extra_arguments()` method **in your views** to eventually filter or manipulate these extra arguments.
+
+.. code-block:: python
+
+    class SelectizeExtraView(AutoView):
+        template_name = 'selectize.html'
+        title = "View using the Selectize autocomplete front library"
+        form = SearchFormExtra
+
+        def get_extra_arguments(self):
+            extras = super(SelectizeExtraView, self).get_extra_arguments()
+            whitelist = ['foo', 'bar']
+            extras = filter(lambda x: x[0] in whitelist, extras)
+            return extras
+
+In the case of a queryset-based Agnocomplete, you can also use the extra arguments in the ``Agnocomplete`` class.
+
+TODO TODO TODO

--- a/docs/autocomplete-definition.rst
+++ b/docs/autocomplete-definition.rst
@@ -257,4 +257,19 @@ You can also override the :meth:`get_extra_arguments()` method **in your views**
 
 In the case of a queryset-based Agnocomplete, you can also use the extra arguments in the ``Agnocomplete`` class.
 
-TODO TODO TODO
+Using Extra arguments with Models/Querysets
++++++++++++++++++++++++++++++++++++++++++++
+
+The extra arguments are passed along to :meth:`items()`, and then to the :meth:`build_filtered_queryset()` method.
+
+This method calls :meth:`build_extra_filtered_queryset()`. By default, this method returns the queryset "verbatim". You can override or overwrite this to perform custom filter on this QS.
+
+.. code-block:: python
+
+    class AutocompletePersonExtra(AutocompletePerson):
+
+        def build_extra_filtered_queryset(self, queryset, **kwargs):
+            location = kwargs.get('location', None)
+            if location:
+                queryset = queryset.filter(location__iexact=location)
+            return queryset


### PR DESCRIPTION
- [x] capturing and transmitting extra arguments from the GET request to the agnocomplete class (via `items()`
- [x] example of uses with `items()`
- [x] same for queryset-based classes
