### PR TITLE
removed deprecations about URL patterns definition

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ master (unreleased)
 - Added support for Django 1.9. Please note that the combination Python 3.3 and Django 1.9 is incompatible - `see Django 1.9 release notes <https://docs.djangoproject.com/en/1.10/releases/1.9/>`_ (#56).
 - Added support for extra arguments passed to the search URL, passed on the Agnocomplete class (#52).
 - Added the ``AgnocompleteUrlProxy`` class, handling autocomplete using a third-party HTTP API (#55).
-
+- Removed Django 1.10 deprecation warnings (#59).
 
 0.5.0 (2016-07-01)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ master (unreleased)
 - Dropped support for Django 1.6 / 1.7 (#54),
 - Added support for Django 1.9. Please note that the combination Python 3.3 and Django 1.9 is incompatible - `see Django 1.9 release notes <https://docs.djangoproject.com/en/1.10/releases/1.9/>`_ (#56).
 - Added support for extra arguments passed to the search URL, passed on the Agnocomplete class (#52).
+- Added the ``AgnocompleteUrlProxy`` class, handling autocomplete using a third-party HTTP API (#55).
 
 
 0.5.0 (2016-07-01)

--- a/agnocomplete/core.py
+++ b/agnocomplete/core.py
@@ -513,6 +513,12 @@ class AgnocompleteUrlProxy(with_metaclass(ABCMeta, AgnocompleteBase)):
         response = requests.get(url.format(**kwargs))
         return response.json()
 
+    def item(self, current_item):
+        return dict(
+            value=text(current_item[self.value_key]),
+            label=text(current_item[self.label_key]),
+        )
+
     def items(self, query=None):
         if not self.is_valid_query(query):
             return []
@@ -521,12 +527,7 @@ class AgnocompleteUrlProxy(with_metaclass(ABCMeta, AgnocompleteBase)):
         http_result = http_result.get('data', [])
         result = []
         for item in http_result:
-            result.append(
-                dict(
-                    value=text(item[self.value_key]),
-                    label=text(item[self.label_key])
-                )
-            )
+            result.append(self.item(item))
         return result
 
     def selected(self, ids):

--- a/agnocomplete/core.py
+++ b/agnocomplete/core.py
@@ -531,15 +531,18 @@ class AgnocompleteUrlProxy(with_metaclass(ABCMeta, AgnocompleteBase)):
 
     def selected(self, ids):
         data = []
+        # Filter out "falsy IDs" (empty string, None, 0...)
+        ids = filter(lambda x: x, ids)
         for _id in ids:
-            # Call to the item URL
-            result = self.http_call(url=self.get_item_url(pk=_id))
-            if 'data' in result and len(result['data']):
-                for item in result['data']:
-                    data.append(
-                        (
-                            text(item[self.value_key]),
-                            text(item[self.label_key])
+            if _id:
+                # Call to the item URL
+                result = self.http_call(url=self.get_item_url(pk=_id))
+                if 'data' in result and len(result['data']):
+                    for item in result['data']:
+                        data.append(
+                            (
+                                text(item[self.value_key]),
+                                text(item[self.label_key])
+                            )
                         )
-                    )
         return data

--- a/agnocomplete/core.py
+++ b/agnocomplete/core.py
@@ -519,11 +519,20 @@ class AgnocompleteUrlProxy(with_metaclass(ABCMeta, AgnocompleteBase)):
             label=text(current_item[self.label_key]),
         )
 
+    def get_http_call_kwargs(self, query):
+        """
+        Return the HTTP query arguments.
+
+        You can override this method to pass further arguments corresponding
+        to your search_url.
+        """
+        return {'q': query}
+
     def items(self, query=None):
         if not self.is_valid_query(query):
             return []
         # Call to search URL
-        http_result = self.http_call(q=query)
+        http_result = self.http_call(**self.get_http_call_kwargs(query))
         http_result = http_result.get('data', [])
         result = []
         for item in http_result:

--- a/agnocomplete/core.py
+++ b/agnocomplete/core.py
@@ -510,7 +510,10 @@ class AgnocompleteUrlProxy(with_metaclass(ABCMeta, AgnocompleteBase)):
         """
         if not url:
             url = self.search_url
-        response = requests.get(url.format(**kwargs))
+        response = requests.get(
+            url.format(**kwargs),
+            headers=self.get_http_headers()
+        )
         return response.json()
 
     def item(self, current_item):
@@ -518,6 +521,14 @@ class AgnocompleteUrlProxy(with_metaclass(ABCMeta, AgnocompleteBase)):
             value=text(current_item[self.value_key]),
             label=text(current_item[self.label_key]),
         )
+
+    def get_http_headers(self):
+        """
+        Return a dictionary that will be added to the HTTP request to the API
+
+        You can overwrite this method, that return an empty dict by default.
+        """
+        return {}
 
     def get_http_call_kwargs(self, query):
         """

--- a/agnocomplete/core.py
+++ b/agnocomplete/core.py
@@ -485,6 +485,8 @@ class AgnocompleteUrlProxy(with_metaclass(ABCMeta, AgnocompleteBase)):
     This class serves as a proxy between your application and a 3rd party
     URL (typically a REST HTTP API).
     """
+    value_key = 'value'
+    label_key = 'label'
 
     def get_search_url(self):
         raise NotImplementedError(
@@ -515,8 +517,17 @@ class AgnocompleteUrlProxy(with_metaclass(ABCMeta, AgnocompleteBase)):
         if not self.is_valid_query(query):
             return []
         # Call to search URL
-        result = self.http_call(q=query)
-        return result.get('data', [])
+        http_result = self.http_call(q=query)
+        http_result = http_result.get('data', [])
+        result = []
+        for item in http_result:
+            result.append(
+                dict(
+                    value=text(item[self.value_key]),
+                    label=text(item[self.label_key])
+                )
+            )
+        return result
 
     def selected(self, ids):
         data = []
@@ -526,6 +537,9 @@ class AgnocompleteUrlProxy(with_metaclass(ABCMeta, AgnocompleteBase)):
             if 'data' in result and len(result['data']):
                 for item in result['data']:
                     data.append(
-                        (text(item['value']), text(item['label']))
+                        (
+                            text(item[self.value_key]),
+                            text(item[self.label_key])
+                        )
                     )
         return data

--- a/agnocomplete/exceptions.py
+++ b/agnocomplete/exceptions.py
@@ -1,6 +1,7 @@
 """
 Agnocomplete exception classes
 """
+from requests.exceptions import HTTPError
 
 
 class UnregisteredAgnocompleteException(Exception):
@@ -20,5 +21,12 @@ class AuthenticationRequiredAgnocompleteException(Exception):
 class ImproperlyConfiguredView(Exception):
     """
     Occurs if you want to misuse an AgnocompleteGenericView
+    """
+    pass
+
+
+class HTTPError(HTTPError):
+    """
+    Occurs when the 3rd party API returns an error code
     """
     pass

--- a/agnocomplete/urls.py
+++ b/agnocomplete/urls.py
@@ -1,7 +1,7 @@
 """
 Agnostic Autocomplete URLS
 """
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from .views import AgnocompleteView, CatalogView
 
 urlpatterns = [
@@ -11,5 +11,3 @@ urlpatterns = [
         name='agnocomplete'),
     url(r'^$', CatalogView.as_view(), name='catalog'),
 ]
-
-urlpatterns = patterns('', *urlpatterns)

--- a/demo/__init__.py
+++ b/demo/__init__.py
@@ -1,0 +1,10 @@
+# This is your fake DB
+DATABASE = (
+    {"pk": 1, 'name': 'first person'},
+    {"pk": 2, 'name': 'second person'},
+    {"pk": 3, 'name': 'third person'},
+    {"pk": 4, 'name': 'fourth person'},
+    {"pk": 5, 'name': 'fifth person'},
+    {"pk": 6, 'name': 'sixth person'},
+    {"pk": 7, 'name': 'seventh person'},
+)

--- a/demo/__init__.py
+++ b/demo/__init__.py
@@ -8,3 +8,5 @@ DATABASE = (
     {"pk": 6, 'name': 'sixth person'},
     {"pk": 7, 'name': 'seventh person'},
 )
+
+GOODAUTHTOKEN = 'GOODAUTHTOKEN'

--- a/demo/autocomplete.py
+++ b/demo/autocomplete.py
@@ -2,7 +2,7 @@
 Autocomplete classes
 """
 from django.core.urlresolvers import reverse_lazy
-from django.utils.encoding import force_text
+from django.utils.encoding import force_text as text
 from django.conf import settings
 
 from agnocomplete.register import register
@@ -73,9 +73,9 @@ class AutocompletePersonShort(AutocompletePerson):
 class AutocompletePersonLabel(AutocompletePerson):
     def item(self, current_item):
         label = {
-            'value': force_text(current_item.pk),
+            'value': text(current_item.pk),
             'label': u'{item} {mail}'.format(
-                item=force_text(current_item), mail=current_item.email)
+                item=text(current_item), mail=current_item.email)
         }
 
         return label
@@ -151,6 +151,12 @@ class AutocompleteUrlSimple(AgnocompleteUrlProxy):
             getattr(settings, 'HTTP_HOST', ''),
             reverse_lazy('url-proxy:simple'),
             r'q={q}'
+        )
+
+    def get_item_url(self, pk):
+        return '{}{}'.format(
+            getattr(settings, 'HTTP_HOST', ''),
+            reverse_lazy('url-proxy:item', args=[pk]),
         )
 
 

--- a/demo/autocomplete.py
+++ b/demo/autocomplete.py
@@ -3,9 +3,14 @@ Autocomplete classes
 """
 from django.core.urlresolvers import reverse_lazy
 from django.utils.encoding import force_text
+from django.conf import settings
 
 from agnocomplete.register import register
-from agnocomplete.core import AgnocompleteChoices, AgnocompleteModel
+from agnocomplete.core import (
+    AgnocompleteChoices,
+    AgnocompleteModel,
+    AgnocompleteUrlProxy,
+)
 from .models import Person, Tag, ContextTag
 from .common import COLORS
 
@@ -139,6 +144,16 @@ class AutocompleteContextTag(AgnocompleteModel):
         return ContextTag.objects.filter(domain__contains=domain)
 
 
+class AutocompleteUrlSimple(AgnocompleteUrlProxy):
+
+    def get_search_url(self):
+        return '{}{}?{}'.format(
+            getattr(settings, 'HTTP_HOST', ''),
+            reverse_lazy('url-proxy:simple'),
+            r'q={q}'
+        )
+
+
 # Registration
 register(AutocompleteColor)
 register(AutocompleteColorExtra)
@@ -152,3 +167,5 @@ register(AutocompletePersonDomain)
 register(AutocompleteCustomUrl)
 register(AutocompleteTag)
 register(AutocompleteContextTag)
+# URL-proxy autocompletion
+register(AutocompleteUrlSimple)

--- a/demo/autocomplete.py
+++ b/demo/autocomplete.py
@@ -210,6 +210,18 @@ class AutocompleteUrlSimpleAuth(AutocompleteUrlMixin):
         return query_args
 
 
+class AutocompleteUrlHeadersAuth(AutocompleteUrlMixin):
+    def get_search_url(self):
+        return '{}{}?{}'.format(
+            getattr(settings, 'HTTP_HOST', ''),
+            reverse_lazy('url-proxy:headers-auth'),
+            r'q={q}'
+        )
+
+    def get_http_headers(self):
+        return {'X-API-TOKEN': GOODAUTHTOKEN}
+
+
 # Registration
 register(AutocompleteColor)
 register(AutocompleteColorExtra)
@@ -228,3 +240,4 @@ register(AutocompleteUrlSimple)
 register(AutocompleteUrlConvert)
 register(AutocompleteUrlConvertComplex)
 register(AutocompleteUrlSimpleAuth)
+register(AutocompleteUrlHeadersAuth)

--- a/demo/autocomplete.py
+++ b/demo/autocomplete.py
@@ -144,7 +144,16 @@ class AutocompleteContextTag(AgnocompleteModel):
         return ContextTag.objects.filter(domain__contains=domain)
 
 
-class AutocompleteUrlSimple(AgnocompleteUrlProxy):
+# Toolbox
+class AutocompleteUrlMixin(AgnocompleteUrlProxy):
+    def get_item_url(self, pk):
+        return '{}{}'.format(
+            getattr(settings, 'HTTP_HOST', ''),
+            reverse_lazy('url-proxy:item', args=[pk]),
+        )
+
+
+class AutocompleteUrlSimple(AutocompleteUrlMixin):
 
     def get_search_url(self):
         return '{}{}?{}'.format(
@@ -153,14 +162,8 @@ class AutocompleteUrlSimple(AgnocompleteUrlProxy):
             r'q={q}'
         )
 
-    def get_item_url(self, pk):
-        return '{}{}'.format(
-            getattr(settings, 'HTTP_HOST', ''),
-            reverse_lazy('url-proxy:item', args=[pk]),
-        )
 
-
-class AutocompleteUrlConvert(AgnocompleteUrlProxy):
+class AutocompleteUrlConvert(AutocompleteUrlMixin):
     """
     Only value_key and label_key are redefined here
     """
@@ -174,10 +177,20 @@ class AutocompleteUrlConvert(AgnocompleteUrlProxy):
             r'q={q}'
         )
 
-    def get_item_url(self, pk):
-        return '{}{}'.format(
+
+class AutocompleteUrlConvertComplex(AgnocompleteUrlProxy):
+    def get_search_url(self):
+        return '{}{}?{}'.format(
             getattr(settings, 'HTTP_HOST', ''),
-            reverse_lazy('url-proxy:item', args=[pk]),
+            reverse_lazy('url-proxy:convert-complex'),
+            r'q={q}'
+        )
+
+    def item(self, current_item):
+        return dict(
+            value=text(current_item['pk']),
+            label='{} {}'.format(
+                current_item['first_name'], current_item['last_name']),
         )
 
 
@@ -197,3 +210,4 @@ register(AutocompleteContextTag)
 # URL-proxy autocompletion
 register(AutocompleteUrlSimple)
 register(AutocompleteUrlConvert)
+register(AutocompleteUrlConvertComplex)

--- a/demo/autocomplete.py
+++ b/demo/autocomplete.py
@@ -160,6 +160,27 @@ class AutocompleteUrlSimple(AgnocompleteUrlProxy):
         )
 
 
+class AutocompleteUrlConvert(AgnocompleteUrlProxy):
+    """
+    Only value_key and label_key are redefined here
+    """
+    value_key = 'pk'
+    label_key = 'name'
+
+    def get_search_url(self):
+        return '{}{}?{}'.format(
+            getattr(settings, 'HTTP_HOST', ''),
+            reverse_lazy('url-proxy:convert'),
+            r'q={q}'
+        )
+
+    def get_item_url(self, pk):
+        return '{}{}'.format(
+            getattr(settings, 'HTTP_HOST', ''),
+            reverse_lazy('url-proxy:item', args=[pk]),
+        )
+
+
 # Registration
 register(AutocompleteColor)
 register(AutocompleteColorExtra)
@@ -175,3 +196,4 @@ register(AutocompleteTag)
 register(AutocompleteContextTag)
 # URL-proxy autocompletion
 register(AutocompleteUrlSimple)
+register(AutocompleteUrlConvert)

--- a/demo/autocomplete.py
+++ b/demo/autocomplete.py
@@ -157,10 +157,9 @@ class AutocompleteUrlMixin(AgnocompleteUrlProxy):
 class AutocompleteUrlSimple(AutocompleteUrlMixin):
 
     def get_search_url(self):
-        return '{}{}?{}'.format(
+        return '{}{}'.format(
             getattr(settings, 'HTTP_HOST', ''),
             reverse_lazy('url-proxy:simple'),
-            r'q={q}'
         )
 
 
@@ -172,19 +171,17 @@ class AutocompleteUrlConvert(AutocompleteUrlMixin):
     label_key = 'name'
 
     def get_search_url(self):
-        return '{}{}?{}'.format(
+        return '{}{}'.format(
             getattr(settings, 'HTTP_HOST', ''),
             reverse_lazy('url-proxy:convert'),
-            r'q={q}'
         )
 
 
 class AutocompleteUrlConvertComplex(AgnocompleteUrlProxy):
     def get_search_url(self):
-        return '{}{}?{}'.format(
+        return '{}{}'.format(
             getattr(settings, 'HTTP_HOST', ''),
             reverse_lazy('url-proxy:convert-complex'),
-            r'q={q}'
         )
 
     def item(self, current_item):
@@ -197,10 +194,9 @@ class AutocompleteUrlConvertComplex(AgnocompleteUrlProxy):
 
 class AutocompleteUrlSimpleAuth(AutocompleteUrlMixin):
     def get_search_url(self):
-        return '{}{}?{}'.format(
+        return '{}{}'.format(
             getattr(settings, 'HTTP_HOST', ''),
             reverse_lazy('url-proxy:simple-auth'),
-            r'q={q}&auth_token={auth_token}'
         )
 
     def get_http_call_kwargs(self, query):
@@ -212,14 +208,24 @@ class AutocompleteUrlSimpleAuth(AutocompleteUrlMixin):
 
 class AutocompleteUrlHeadersAuth(AutocompleteUrlMixin):
     def get_search_url(self):
-        return '{}{}?{}'.format(
+        return '{}{}'.format(
             getattr(settings, 'HTTP_HOST', ''),
             reverse_lazy('url-proxy:headers-auth'),
-            r'q={q}'
         )
 
     def get_http_headers(self):
         return {'X-API-TOKEN': GOODAUTHTOKEN}
+
+
+class AutocompleteUrlSimplePost(AutocompleteUrlMixin):
+    method = 'post'
+
+    def get_search_url(self):
+        # Search using POST, no need to send query args
+        return '{}{}'.format(
+            getattr(settings, 'HTTP_HOST', ''),
+            reverse_lazy('url-proxy:simple-post'),
+        )
 
 
 # Registration
@@ -241,3 +247,4 @@ register(AutocompleteUrlConvert)
 register(AutocompleteUrlConvertComplex)
 register(AutocompleteUrlSimpleAuth)
 register(AutocompleteUrlHeadersAuth)
+register(AutocompleteUrlSimplePost)

--- a/demo/autocomplete.py
+++ b/demo/autocomplete.py
@@ -13,6 +13,7 @@ from agnocomplete.core import (
 )
 from .models import Person, Tag, ContextTag
 from .common import COLORS
+from . import GOODAUTHTOKEN
 
 
 class AutocompleteColor(AgnocompleteChoices):
@@ -194,6 +195,21 @@ class AutocompleteUrlConvertComplex(AgnocompleteUrlProxy):
         )
 
 
+class AutocompleteUrlSimpleAuth(AutocompleteUrlMixin):
+    def get_search_url(self):
+        return '{}{}?{}'.format(
+            getattr(settings, 'HTTP_HOST', ''),
+            reverse_lazy('url-proxy:simple-auth'),
+            r'q={q}&auth_token={auth_token}'
+        )
+
+    def get_http_call_kwargs(self, query):
+        query_args = super(
+            AutocompleteUrlSimpleAuth, self).get_http_call_kwargs(query)
+        query_args['auth_token'] = GOODAUTHTOKEN
+        return query_args
+
+
 # Registration
 register(AutocompleteColor)
 register(AutocompleteColorExtra)
@@ -211,3 +227,4 @@ register(AutocompleteContextTag)
 register(AutocompleteUrlSimple)
 register(AutocompleteUrlConvert)
 register(AutocompleteUrlConvertComplex)
+register(AutocompleteUrlSimpleAuth)

--- a/demo/forms.py
+++ b/demo/forms.py
@@ -96,3 +96,7 @@ class PersonContextTagModelForm(UserContextFormMixin, forms.ModelForm):
     class Meta:
         model = PersonContextTag
         fields = '__all__'
+
+
+class UrlProxyForm(forms.Form):
+    person = fields.AgnocompleteField('AutocompleteUrlSimple')

--- a/demo/forms.py
+++ b/demo/forms.py
@@ -101,8 +101,7 @@ class PersonContextTagModelForm(UserContextFormMixin, forms.ModelForm):
         fields = '__all__'
 
 
-class UrlProxyForm(forms.Form):
-    person = fields.AgnocompleteField('AutocompleteUrlSimple')
+class UrlProxyFormMixin(object):
     help_text = """
 We're not using the usual fixture here. Here's our "database":
 -------
@@ -110,3 +109,11 @@ We're not using the usual fixture here. Here's our "database":
 {}
 </pre>
 """.format(pprint.pformat(DATABASE))
+
+
+class UrlProxyForm(UrlProxyFormMixin, forms.Form):
+    person = fields.AgnocompleteField('AutocompleteUrlSimple')
+
+
+class UrlProxyConvertForm(UrlProxyFormMixin, forms.Form):
+    person = fields.AgnocompleteField('AutocompleteUrlConvert')

--- a/demo/forms.py
+++ b/demo/forms.py
@@ -116,11 +116,12 @@ class UrlProxyForm(UrlProxyFormMixin, forms.Form):
 
 
 class UrlProxyConvertForm(UrlProxyFormMixin, forms.Form):
-    person = fields.AgnocompleteField('AutocompleteUrlConvert')
-
-
-class UrlProxyConvertComplexForm(UrlProxyFormMixin, forms.Form):
-    person = fields.AgnocompleteField('AutocompleteUrlConvertComplex')
+    person_convert_simple = fields.AgnocompleteField(
+        'AutocompleteUrlConvert',
+        help_text='Simple returned data conversion')
+    person_convert_complex = fields.AgnocompleteField(
+        'AutocompleteUrlConvertComplex',
+        help_text='Complex returned data conversion')
 
 
 class UrlProxyAuthForm(UrlProxyFormMixin, forms.Form):

--- a/demo/forms.py
+++ b/demo/forms.py
@@ -121,3 +121,9 @@ class UrlProxyConvertForm(UrlProxyFormMixin, forms.Form):
 
 class UrlProxyConvertComplexForm(UrlProxyFormMixin, forms.Form):
     person = fields.AgnocompleteField('AutocompleteUrlConvertComplex')
+
+
+class UrlProxyAuthForm(UrlProxyFormMixin, forms.Form):
+    person = fields.AgnocompleteField(
+        'AutocompleteUrlSimpleAuth',
+        help_text='Query-arg based authentication')

--- a/demo/forms.py
+++ b/demo/forms.py
@@ -112,7 +112,14 @@ We're not using the usual fixture here. Here's our "database":
 
 
 class UrlProxyForm(UrlProxyFormMixin, forms.Form):
-    person = fields.AgnocompleteField('AutocompleteUrlSimple')
+    person_simple = fields.AgnocompleteField(
+        'AutocompleteUrlSimple',
+        help_text='Simple search using GET',
+    )
+    person_post = fields.AgnocompleteField(
+        'AutocompleteUrlSimplePost',
+        help_text='Simple search using POST',
+    )
 
 
 class UrlProxyConvertForm(UrlProxyFormMixin, forms.Form):

--- a/demo/forms.py
+++ b/demo/forms.py
@@ -1,6 +1,8 @@
 """
 Form classes
 """
+import pprint
+
 from django import forms
 from django.core.urlresolvers import reverse_lazy
 
@@ -20,6 +22,7 @@ from .autocomplete import (
 )
 from .models import PersonTag, PersonContextTag
 from .fields import ModelMultipleDomainField
+from . import DATABASE
 
 
 class SearchForm(forms.Form):
@@ -100,3 +103,10 @@ class PersonContextTagModelForm(UserContextFormMixin, forms.ModelForm):
 
 class UrlProxyForm(forms.Form):
     person = fields.AgnocompleteField('AutocompleteUrlSimple')
+    help_text = """
+We're not using the usual fixture here. Here's our "database":
+-------
+<pre>
+{}
+</pre>
+""".format(pprint.pformat(DATABASE))

--- a/demo/forms.py
+++ b/demo/forms.py
@@ -117,3 +117,7 @@ class UrlProxyForm(UrlProxyFormMixin, forms.Form):
 
 class UrlProxyConvertForm(UrlProxyFormMixin, forms.Form):
     person = fields.AgnocompleteField('AutocompleteUrlConvert')
+
+
+class UrlProxyConvertComplexForm(UrlProxyFormMixin, forms.Form):
+    person = fields.AgnocompleteField('AutocompleteUrlConvertComplex')

--- a/demo/forms.py
+++ b/demo/forms.py
@@ -125,6 +125,9 @@ class UrlProxyConvertForm(UrlProxyFormMixin, forms.Form):
 
 
 class UrlProxyAuthForm(UrlProxyFormMixin, forms.Form):
-    person = fields.AgnocompleteField(
+    person_query_auth = fields.AgnocompleteField(
         'AutocompleteUrlSimpleAuth',
         help_text='Query-arg based authentication')
+    person_headers_auth = fields.AgnocompleteField(
+        'AutocompleteUrlHeadersAuth',
+        help_text='Headers-based authentication')

--- a/demo/settings.py
+++ b/demo/settings.py
@@ -159,3 +159,6 @@ AGNOCOMPLETE_DEFAULT_QUERYSIZE = 5
 AGNOCOMPLETE_MIN_QUERYSIZE = 4
 # 3. agnocomplete prefix
 AGNOCOMPLETE_NAMESPACE = 'autocomplete'
+
+# Demo specifics
+HTTP_HOST = 'http://127.0.0.1:8000'

--- a/demo/settings.py
+++ b/demo/settings.py
@@ -138,7 +138,7 @@ LOGGING = {
             'handlers': ['console'],
         },
         'demo': {
-            'level': 'DEBUG',
+            'level': 'INFO',
             'handlers': ['console'],
         }
     }

--- a/demo/templates/base.html
+++ b/demo/templates/base.html
@@ -10,6 +10,9 @@
     </head>
     <body>
         <h1>{{ title }}</h1>
+        {% if form.help_text %}
+        <p style="color: #444;">{{ form.help_text|safe|linebreaks }}</p>
+        {% endif %}
         <form action="." method="post">
             {{ form }}
             <input type="submit" value="OK">

--- a/demo/templates/base.html
+++ b/demo/templates/base.html
@@ -7,6 +7,12 @@
         {% block extra_head %}
         <!-- put your extra head elements (scripts, css) here -->
         {% endblock %}
+        <style>
+            .helptext {
+                color: #555;
+                font-size: .8em;
+            }
+        </style>
     </head>
     <body>
         <h1>{{ title }}</h1>
@@ -15,7 +21,7 @@
         {% endif %}
         <form action="." method="post">
             {{ form }}
-            <input type="submit" value="OK">
+            <p><input type="submit" value="OK">
         </form>
 
         <hr>

--- a/demo/templates/base.html
+++ b/demo/templates/base.html
@@ -20,7 +20,7 @@
         <p style="color: #444;">{{ form.help_text|safe|linebreaks }}</p>
         {% endif %}
         <form action="." method="post">
-            {{ form }}
+            {{ form.as_p }}
             <p><input type="submit" value="OK">
         </form>
 

--- a/demo/templates/includes/nav.html
+++ b/demo/templates/includes/nav.html
@@ -23,4 +23,5 @@
     <li><a href="{% url 'url-proxy-simple' %}">Simple URL, returned data without transformation</a></li>
     <li><a href="{% url 'url-proxy-convert' %}">Simple URL, returned data with little transformation</a></li>
     <li><a href="{% url 'url-proxy-convert-complex' %}">Simple URL, returned data with complex transformations</a></li>
+    <li><a href="{% url 'url-proxy-auth' %}">Authenticated URLs</a></li>
 </ul>

--- a/demo/templates/includes/nav.html
+++ b/demo/templates/includes/nav.html
@@ -21,7 +21,6 @@
 <h2>URL Proxy</h2>
 <ul>
     <li><a href="{% url 'url-proxy-simple' %}">Simple URL, returned data without transformation</a></li>
-    <li><a href="{% url 'url-proxy-convert' %}">Simple URL, returned data with little transformation</a></li>
-    <li><a href="{% url 'url-proxy-convert-complex' %}">Simple URL, returned data with complex transformations</a></li>
+    <li><a href="{% url 'url-proxy-convert' %}">Simple URL, returned data with more or less data converted</a></li>
     <li><a href="{% url 'url-proxy-auth' %}">Authenticated URLs</a></li>
 </ul>

--- a/demo/templates/includes/nav.html
+++ b/demo/templates/includes/nav.html
@@ -21,4 +21,5 @@
 <h2>URL Proxy</h2>
 <ul>
     <li><a href="{% url 'url-proxy-simple' %}">Simple URL, returned data without transformation</a></li>
+    <li><a href="{% url 'url-proxy-convert' %}">Simple URL, returned data with little transformation</a></li>
 </ul>

--- a/demo/templates/includes/nav.html
+++ b/demo/templates/includes/nav.html
@@ -22,4 +22,5 @@
 <ul>
     <li><a href="{% url 'url-proxy-simple' %}">Simple URL, returned data without transformation</a></li>
     <li><a href="{% url 'url-proxy-convert' %}">Simple URL, returned data with little transformation</a></li>
+    <li><a href="{% url 'url-proxy-convert-complex' %}">Simple URL, returned data with complex transformations</a></li>
 </ul>

--- a/demo/templates/includes/nav.html
+++ b/demo/templates/includes/nav.html
@@ -1,14 +1,24 @@
-Demo pages:
+<h1>Demo pages:</h1>
 <ul>
     <li><a href="{% url 'home' %}">Index</a></li>
     <li><a href="{% url 'filled-form' %}">Filled form</a></li>
-    <li><a href="{% url 'selectize' %}">[JS DEMO] Selectize</a></li>
+</ul>
+<h2>Simple JS Demos</h2>
+<ul>
+    <li><a href="{% url 'selectize' %}">Selectize</a></li>
     <li><a href="{% url 'selectize-extra' %}">[JS DEMO] Selectize with extra argument in query payload</a></li>
-    <li><a href="{% url 'selectize-multi' %}">[JS DEMO] Selectize w/ multi-selection</a></li>
-    <li><a href="{% url 'select2' %}">[JS DEMO] Select2</a></li>
-    <li><a href="{% url 'jquery-autocomplete' %}">[JS DEMO] JQuery Autocomplete</a></li>
-    <li><a href="{% url 'typeahead' %}">[JS DEMO] Typeahead</a></li>
-    <li><a href="{% url 'selectize-tag' %}">[JS DEMO] Person/Tag form (multi-selection + models)</a></li>
-    <li><a href="{% url 'selectize-model-tag' %}">[JS DEMO] Person/Tag form (multi-selection + models with modelforms)</a></li>
-    <li><a href="{% url 'selectize-model-tag-with-create' %}">[JS DEMO] Person/Tag form (multi-selection + models with modelforms + creation mode)</a></li>
+    <li><a href="{% url 'selectize-multi' %}">Selectize w/ multi-selection</a></li>
+    <li><a href="{% url 'select2' %}">Select2</a></li>
+    <li><a href="{% url 'jquery-autocomplete' %}">JQuery Autocomplete</a></li>
+    <li><a href="{% url 'typeahead' %}">Typeahead</a></li>
+</ul>
+<h2>Multiple selection using Django Models</h2>
+<ul>
+    <li><a href="{% url 'selectize-tag' %}">Person/Tag form (multi-selection + models)</a></li>
+    <li><a href="{% url 'selectize-model-tag' %}">Person/Tag form (multi-selection + models with modelforms)</a></li>
+    <li><a href="{% url 'selectize-model-tag-with-create' %}">Person/Tag form (multi-selection + models with modelforms + creation mode)</a></li>
+</ul>
+<h2>URL Proxy</h2>
+<ul>
+    <li><a href="{% url 'url-proxy-simple' %}">Simple URL, returned data without transformation</a></li>
 </ul>

--- a/demo/tests/__init__.py
+++ b/demo/tests/__init__.py
@@ -31,7 +31,7 @@ class LoaddataLiveTestCase(LoaddataMixin, LiveServerTestCase):
 class RegistryTestGeneric(LoaddataTestCase):
 
     def _test_registry_keys(self, keys):
-        self.assertEqual(len(keys), 17)
+        self.assertEqual(len(keys), 18)
         self.assertIn("AutocompleteColor", keys)
         self.assertIn("AutocompleteColorExtra", keys)
         self.assertIn("AutocompletePerson", keys)
@@ -51,6 +51,7 @@ class RegistryTestGeneric(LoaddataTestCase):
         self.assertIn("AutocompleteContextTag", keys)
         # URL Proxies
         self.assertIn("AutocompleteUrlSimple", keys)
+        self.assertIn("AutocompleteUrlSimplePost", keys)
         self.assertIn("AutocompleteUrlConvert", keys)
         self.assertIn("AutocompleteUrlConvertComplex", keys)
         self.assertIn("AutocompleteUrlSimpleAuth", keys)

--- a/demo/tests/__init__.py
+++ b/demo/tests/__init__.py
@@ -1,13 +1,31 @@
-from django.test import TestCase
+from django.test import TestCase, LiveServerTestCase
 from django.core.management import call_command
 
 
-class LoaddataTestCase(TestCase):
+class LoaddataMixin(object):
     def setUp(self):
-        super(LoaddataTestCase, self).setUp()
+        super(LoaddataMixin, self).setUp()
         # Explicitly load initial data, not loaded by default since Django 1.9
         # And keep this command quiet
         call_command("loaddata", "initial_data", verbosity=0)
+
+
+class LoaddataTestCase(LoaddataMixin, TestCase):
+    """
+    Test class that loads data.
+
+    ref: starting from Django 1.9, there's no more automatic implicit loaddata
+    for initial_data fixtures.
+    """
+
+
+class LoaddataLiveTestCase(LoaddataMixin, LiveServerTestCase):
+    """
+    Test class that loads data, along with the LiveServer service activated.
+
+    ref: starting from Django 1.9, there's no more automatic implicit loaddata
+    for initial_data fixtures.
+    """
 
 
 class RegistryTestGeneric(LoaddataTestCase):

--- a/demo/tests/__init__.py
+++ b/demo/tests/__init__.py
@@ -13,7 +13,7 @@ class LoaddataTestCase(TestCase):
 class RegistryTestGeneric(LoaddataTestCase):
 
     def _test_registry_keys(self, keys):
-        self.assertEqual(len(keys), 16)
+        self.assertEqual(len(keys), 17)
         self.assertIn("AutocompleteColor", keys)
         self.assertIn("AutocompleteColorExtra", keys)
         self.assertIn("AutocompletePerson", keys)
@@ -36,6 +36,7 @@ class RegistryTestGeneric(LoaddataTestCase):
         self.assertIn("AutocompleteUrlConvert", keys)
         self.assertIn("AutocompleteUrlConvertComplex", keys)
         self.assertIn("AutocompleteUrlSimpleAuth", keys)
+        self.assertIn("AutocompleteUrlHeadersAuth", keys)
 
 
 class MockRequestUser(object):

--- a/demo/tests/__init__.py
+++ b/demo/tests/__init__.py
@@ -13,7 +13,7 @@ class LoaddataTestCase(TestCase):
 class RegistryTestGeneric(LoaddataTestCase):
 
     def _test_registry_keys(self, keys):
-        self.assertEqual(len(keys), 14)
+        self.assertEqual(len(keys), 15)
         self.assertIn("AutocompleteColor", keys)
         self.assertIn("AutocompleteColorExtra", keys)
         self.assertIn("AutocompletePerson", keys)
@@ -34,6 +34,7 @@ class RegistryTestGeneric(LoaddataTestCase):
         # URL Proxies
         self.assertIn("AutocompleteUrlSimple", keys)
         self.assertIn("AutocompleteUrlConvert", keys)
+        self.assertIn("AutocompleteUrlConvertComplex", keys)
 
 
 class MockRequestUser(object):

--- a/demo/tests/__init__.py
+++ b/demo/tests/__init__.py
@@ -13,7 +13,7 @@ class LoaddataTestCase(TestCase):
 class RegistryTestGeneric(LoaddataTestCase):
 
     def _test_registry_keys(self, keys):
-        self.assertEqual(len(keys), 15)
+        self.assertEqual(len(keys), 16)
         self.assertIn("AutocompleteColor", keys)
         self.assertIn("AutocompleteColorExtra", keys)
         self.assertIn("AutocompletePerson", keys)
@@ -35,6 +35,7 @@ class RegistryTestGeneric(LoaddataTestCase):
         self.assertIn("AutocompleteUrlSimple", keys)
         self.assertIn("AutocompleteUrlConvert", keys)
         self.assertIn("AutocompleteUrlConvertComplex", keys)
+        self.assertIn("AutocompleteUrlSimpleAuth", keys)
 
 
 class MockRequestUser(object):

--- a/demo/tests/__init__.py
+++ b/demo/tests/__init__.py
@@ -13,7 +13,7 @@ class LoaddataTestCase(TestCase):
 class RegistryTestGeneric(LoaddataTestCase):
 
     def _test_registry_keys(self, keys):
-        self.assertEqual(len(keys), 13)
+        self.assertEqual(len(keys), 14)
         self.assertIn("AutocompleteColor", keys)
         self.assertIn("AutocompleteColorExtra", keys)
         self.assertIn("AutocompletePerson", keys)
@@ -33,6 +33,7 @@ class RegistryTestGeneric(LoaddataTestCase):
         self.assertIn("AutocompleteContextTag", keys)
         # URL Proxies
         self.assertIn("AutocompleteUrlSimple", keys)
+        self.assertIn("AutocompleteUrlConvert", keys)
 
 
 class MockRequestUser(object):

--- a/demo/tests/__init__.py
+++ b/demo/tests/__init__.py
@@ -13,7 +13,7 @@ class LoaddataTestCase(TestCase):
 class RegistryTestGeneric(LoaddataTestCase):
 
     def _test_registry_keys(self, keys):
-        self.assertEqual(len(keys), 12)
+        self.assertEqual(len(keys), 13)
         self.assertIn("AutocompleteColor", keys)
         self.assertIn("AutocompleteColorExtra", keys)
         self.assertIn("AutocompletePerson", keys)
@@ -31,6 +31,8 @@ class RegistryTestGeneric(LoaddataTestCase):
         # Customized views demo
         self.assertNotIn("HiddenAutocomplete", keys)
         self.assertIn("AutocompleteContextTag", keys)
+        # URL Proxies
+        self.assertIn("AutocompleteUrlSimple", keys)
 
 
 class MockRequestUser(object):

--- a/demo/tests/test_core.py
+++ b/demo/tests/test_core.py
@@ -16,7 +16,7 @@ from ..autocomplete import (
     AutocompleteChoicesPagesOverride,
     AutocompletePersonQueryset,
     AutocompletePersonMisconfigured,
-    AutocompletePersonDomain
+    AutocompletePersonDomain,
 )
 from ..models import Person
 from . import MockRequestUser, LoaddataTestCase

--- a/demo/tests/test_demo_views.py
+++ b/demo/tests/test_demo_views.py
@@ -227,6 +227,10 @@ class JSDemoViews(TestCase):
         response = self.client.get(reverse('url-proxy-convert'))
         self.assertEqual(response.status_code, 200)
 
+    def test_url_proxy_convert_complex(self):
+        response = self.client.get(reverse('url-proxy-convert-complex'))
+        self.assertEqual(response.status_code, 200)
+
 
 class FormValidationViewTest(LoaddataTestCase):
 

--- a/demo/tests/test_demo_views.py
+++ b/demo/tests/test_demo_views.py
@@ -219,6 +219,10 @@ class JSDemoViews(TestCase):
         response = self.client.get(reverse('search-context'))
         self.assertEqual(response.status_code, 200)
 
+    def test_url_proxy_simple(self):
+        response = self.client.get(reverse('url-proxy-simple'))
+        self.assertEqual(response.status_code, 200)
+
 
 class FormValidationViewTest(LoaddataTestCase):
 

--- a/demo/tests/test_demo_views.py
+++ b/demo/tests/test_demo_views.py
@@ -3,10 +3,17 @@ from django.test import TestCase
 from django.core.urlresolvers import reverse
 from django.test import override_settings
 
+import mock
+from requests.exceptions import HTTPError
+
 from agnocomplete import get_namespace
 from agnocomplete.views import AgnocompleteJSONView
+from ..autocomplete import (
+    AutocompleteUrlSimpleAuth,
+    AutocompleteUrlHeadersAuth,
+)
 from ..models import Person, Tag, PersonTag, ContextTag, PersonContextTag
-from . import LoaddataTestCase
+from . import LoaddataTestCase, LoaddataLiveTestCase
 
 
 class HomeTest(TestCase):
@@ -586,3 +593,90 @@ class SelectizeExtraTest(LoaddataTestCase):
         result = json.loads(response.content.decode())
         data = result.get('data')
         self.assertEqual(len(data), 2)
+
+
+@override_settings(
+    HTTP_HOST='',
+)
+class UrlProxyAuthTest(LoaddataLiveTestCase):
+    def test_search_query_auth(self):
+        # URL construct
+        instance = AutocompleteUrlSimpleAuth()
+        search_url = instance.search_url
+        klass = 'demo.autocomplete.AutocompleteUrlSimpleAuth'
+        with mock.patch(klass + '.get_search_url') as mock_auto:
+            mock_auto.return_value = self.live_server_url + search_url
+            # Search using the URL proxy view
+            search_url = get_namespace() + ':agnocomplete'
+            response = self.client.get(
+                reverse(search_url, args=['AutocompleteUrlSimpleAuth']),
+                data={'q': "person"}
+            )
+            # All the persons
+            result = json.loads(response.content.decode())
+            data = result.get('data')
+            self.assertEqual(len(data), 7)
+
+    def test_search_headers_auth(self):
+        # URL construct
+        instance = AutocompleteUrlHeadersAuth()
+        search_url = instance.search_url
+        klass = 'demo.autocomplete.AutocompleteUrlHeadersAuth'
+        with mock.patch(klass + '.get_search_url') as mock_auto:
+            mock_auto.return_value = self.live_server_url + search_url
+            # Search using the URL proxy view
+            search_url = get_namespace() + ':agnocomplete'
+            response = self.client.get(
+                reverse(search_url, args=['AutocompleteUrlHeadersAuth']),
+                data={'q': "person"}
+            )
+            # All the persons
+            result = json.loads(response.content.decode())
+            data = result.get('data')
+            self.assertEqual(len(data), 7)
+
+    def test_search_query_wrong_auth(self):
+        # URL construct
+        instance = AutocompleteUrlSimpleAuth()
+        search_url = instance.search_url
+        klass = 'demo.autocomplete.AutocompleteUrlSimpleAuth'
+        with mock.patch(klass + '.get_search_url') as mock_auto:
+            mock_auto.return_value = self.live_server_url + search_url
+            # Search using the URL proxy view
+            search_url = get_namespace() + ':agnocomplete'
+
+            with mock.patch(klass + '.get_http_call_kwargs') as mock_headers:
+                mock_headers.return_value = {
+                    'auth_token': 'BADAUTHTOKEN',
+                    'q': 'person',
+                }
+                # TODO: We'll probably have to handle a custom error process
+                # ATM we're passing the HTTPError back to the front-end.
+                with self.assertRaises(HTTPError):
+                    self.client.get(
+                        reverse(
+                            search_url, args=['AutocompleteUrlSimpleAuth']),
+                        data={'q': "person"}
+                    )
+
+    def test_search_headers_wrong_auth(self):
+        # URL construct
+        instance = AutocompleteUrlHeadersAuth()
+        search_url = instance.search_url
+        klass = 'demo.autocomplete.AutocompleteUrlHeadersAuth'
+        with mock.patch(klass + '.get_search_url') as mock_auto:
+            mock_auto.return_value = self.live_server_url + search_url
+            # Search using the URL proxy view
+            search_url = get_namespace() + ':agnocomplete'
+            with mock.patch(klass + '.get_http_headers') as mock_headers:
+                mock_headers.return_value = {
+                    'NOTHING': 'HERE'
+                }
+                # TODO: We'll probably have to handle a custom error process
+                # ATM we're passing the HTTPError back to the front-end.
+                with self.assertRaises(HTTPError):
+                    self.client.get(
+                        reverse(
+                            search_url, args=['AutocompleteUrlHeadersAuth']),
+                        data={'q': "person"}
+                    )

--- a/demo/tests/test_demo_views.py
+++ b/demo/tests/test_demo_views.py
@@ -223,6 +223,10 @@ class JSDemoViews(TestCase):
         response = self.client.get(reverse('url-proxy-simple'))
         self.assertEqual(response.status_code, 200)
 
+    def test_url_proxy_convert(self):
+        response = self.client.get(reverse('url-proxy-convert'))
+        self.assertEqual(response.status_code, 200)
+
 
 class FormValidationViewTest(LoaddataTestCase):
 

--- a/demo/tests/test_demo_views.py
+++ b/demo/tests/test_demo_views.py
@@ -231,6 +231,10 @@ class JSDemoViews(TestCase):
         response = self.client.get(reverse('url-proxy-convert-complex'))
         self.assertEqual(response.status_code, 200)
 
+    def test_url_proxy_auth(self):
+        response = self.client.get(reverse('url-proxy-auth'))
+        self.assertEqual(response.status_code, 200)
+
 
 class FormValidationViewTest(LoaddataTestCase):
 

--- a/demo/tests/test_demo_views.py
+++ b/demo/tests/test_demo_views.py
@@ -227,10 +227,6 @@ class JSDemoViews(TestCase):
         response = self.client.get(reverse('url-proxy-convert'))
         self.assertEqual(response.status_code, 200)
 
-    def test_url_proxy_convert_complex(self):
-        response = self.client.get(reverse('url-proxy-convert-complex'))
-        self.assertEqual(response.status_code, 200)
-
     def test_url_proxy_auth(self):
         response = self.client.get(reverse('url-proxy-auth'))
         self.assertEqual(response.status_code, 200)

--- a/demo/tests/test_url_proxy.py
+++ b/demo/tests/test_url_proxy.py
@@ -8,7 +8,7 @@ from django.utils.encoding import force_text as text
 import mock
 
 from ..autocomplete import AutocompleteUrlSimple, AutocompleteUrlConvert
-from ..views_proxy import DATABASE
+from .. import DATABASE
 RESULT_DICT = [{'value': text(item['pk']), 'label': text(item['name'])} for item in DATABASE]  # noqa
 
 

--- a/demo/tests/test_url_proxy.py
+++ b/demo/tests/test_url_proxy.py
@@ -18,8 +18,6 @@ RESULT_DICT = [{'value': text(item['pk']), 'label': text(item['name'])} for item
 
 
 @override_settings(
-    AGNOCOMPLETE_DEFAULT_QUERYSIZE=2,
-    AGNOCOMPLETE_MIN_QUERYSIZE=2,
     HTTP_HOST='',
 )
 class AutocompleteUrlSimpleTest(LiveServerTestCase):
@@ -65,8 +63,6 @@ class AutocompleteUrlSimpleTest(LiveServerTestCase):
 
 
 @override_settings(
-    AGNOCOMPLETE_DEFAULT_QUERYSIZE=2,
-    AGNOCOMPLETE_MIN_QUERYSIZE=2,
     HTTP_HOST='',
 )
 class AutocompleteUrlConvertTest(LiveServerTestCase):
@@ -92,8 +88,6 @@ class AutocompleteUrlConvertTest(LiveServerTestCase):
 
 
 @override_settings(
-    AGNOCOMPLETE_DEFAULT_QUERYSIZE=2,
-    AGNOCOMPLETE_MIN_QUERYSIZE=2,
     HTTP_HOST='',
 )
 class AutocompleteUrlConvertComplexTest(LiveServerTestCase):
@@ -120,8 +114,6 @@ class AutocompleteUrlConvertComplexTest(LiveServerTestCase):
 
 
 @override_settings(
-    AGNOCOMPLETE_DEFAULT_QUERYSIZE=2,
-    AGNOCOMPLETE_MIN_QUERYSIZE=2,
     HTTP_HOST='',
 )
 class AutocompleteUrlSimpleAuthTest(LiveServerTestCase):

--- a/demo/tests/test_url_proxy.py
+++ b/demo/tests/test_url_proxy.py
@@ -1,0 +1,92 @@
+"""
+Tests for URL Proxy views
+"""
+import json
+
+from django.test import TestCase, LiveServerTestCase
+from django.core.urlresolvers import reverse
+from django.test import override_settings
+import mock
+
+from ..autocomplete import AutocompleteUrlSimple
+from ..views_proxy import DATABASE
+RESULT_DICT = [{'value': item['pk'], 'label': item['name']} for item in DATABASE]  # noqa
+
+
+class UrlProxySimpleTest(TestCase):
+
+    def test_simple_query(self):
+        response = self.client.get(
+            reverse('url-proxy:simple'), {'q': 'person'})
+        self.assertEqual(response.status_code, 200)
+        result = json.loads(response.content.decode())
+        self.assertIn('data', result)
+        data = result['data']
+        # Result data is a list
+        self.assertTrue(isinstance(data, list))
+        # Result data is not empty
+        self.assertTrue(data)
+        self.assertEqual(len(data), len(DATABASE))
+        for item in data:
+            self.assertIn('value', item)
+            self.assertIn('label', item)
+            # The label contains "person"
+            self.assertIn('person', item['label'])
+
+    def test_single(self):
+        response = self.client.get(
+            reverse('url-proxy:simple'), {'q': 'first'})
+        self.assertEqual(response.status_code, 200)
+        result = json.loads(response.content.decode())
+        self.assertIn('data', result)
+        data = result['data']
+        # Result data is a list
+        self.assertTrue(isinstance(data, list))
+        # Result data is not empty
+        self.assertTrue(data)
+        self.assertEqual(len(data), 1)
+
+    def test_empty_query(self):
+        response = self.client.get(
+            reverse('url-proxy:simple'), {'q': 'lorem ipsum'})
+        self.assertEqual(response.status_code, 200)
+        result = json.loads(response.content.decode())
+        self.assertIn('data', result)
+        data = result['data']
+        # Result data is a list
+        self.assertTrue(isinstance(data, list))
+        # Result data is  empty
+        self.assertFalse(data)
+
+
+@override_settings(
+    AGNOCOMPLETE_DEFAULT_QUERYSIZE=2,
+    AGNOCOMPLETE_MIN_QUERYSIZE=2,
+    HTTP_HOST='',
+)
+class AutocompleteUrlSimpleTest(LiveServerTestCase):
+
+    def test_search(self):
+        instance = AutocompleteUrlSimple()
+        # "mock" Change URL by adding the host
+        search_url = instance.search_url
+        with mock.patch('demo.autocomplete.AutocompleteUrlSimple'
+                        '.get_search_url') as mock_auto:
+            mock_auto.return_value = self.live_server_url + search_url
+            self.assertEqual(list(instance.items()), [])
+            # Limit is 2, a 1-char-long query should be empty
+            self.assertEqual(list(instance.items(query='p')), [])
+            # Starting from 2 chars, it's okay
+            self.assertEqual(
+                list(instance.items(query='person')), RESULT_DICT
+            )
+
+            self.assertEqual(
+                list(instance.items(query='first')), [
+                    {'value': 1, 'label': 'first person'},
+                ],
+            )
+            self.assertEqual(
+                list(instance.items(query='zzzzz')),
+                []
+            )

--- a/demo/tests/test_url_proxy.py
+++ b/demo/tests/test_url_proxy.py
@@ -1,85 +1,15 @@
 """
 Tests for URL Proxy views
 """
-import json
-
-from django.test import TestCase, LiveServerTestCase
-from django.core.urlresolvers import reverse
+from django.test import LiveServerTestCase
 from django.test import override_settings
 from django.utils.encoding import force_text as text
 
 import mock
 
-from ..autocomplete import AutocompleteUrlSimple
+from ..autocomplete import AutocompleteUrlSimple, AutocompleteUrlConvert
 from ..views_proxy import DATABASE
-RESULT_DICT = [{'value': item['pk'], 'label': item['name']} for item in DATABASE]  # noqa
-
-
-class UrlProxySimpleTest(TestCase):
-
-    def test_simple_query(self):
-        response = self.client.get(
-            reverse('url-proxy:simple'), {'q': 'person'})
-        self.assertEqual(response.status_code, 200)
-        result = json.loads(response.content.decode())
-        self.assertIn('data', result)
-        data = result['data']
-        # Result data is a list
-        self.assertTrue(isinstance(data, list))
-        # Result data is not empty
-        self.assertTrue(data)
-        self.assertEqual(len(data), len(DATABASE))
-        for item in data:
-            self.assertIn('value', item)
-            self.assertIn('label', item)
-            # The label contains "person"
-            self.assertIn('person', item['label'])
-
-    def test_single(self):
-        response = self.client.get(
-            reverse('url-proxy:simple'), {'q': 'first'})
-        self.assertEqual(response.status_code, 200)
-        result = json.loads(response.content.decode())
-        self.assertIn('data', result)
-        data = result['data']
-        # Result data is a list
-        self.assertTrue(isinstance(data, list))
-        # Result data is not empty
-        self.assertTrue(data)
-        self.assertEqual(len(data), 1)
-
-    def test_empty_query(self):
-        response = self.client.get(
-            reverse('url-proxy:simple'), {'q': 'lorem ipsum'})
-        self.assertEqual(response.status_code, 200)
-        result = json.loads(response.content.decode())
-        self.assertIn('data', result)
-        data = result['data']
-        # Result data is a list
-        self.assertTrue(isinstance(data, list))
-        # Result data is empty
-        self.assertFalse(data)
-
-    def test_item(self):
-        response = self.client.get(reverse('url-proxy:item', args=[4]))
-        self.assertEqual(response.status_code, 200)
-        result = json.loads(response.content.decode())
-        self.assertIn('data', result)
-        data = result['data']
-        # Result data is a list
-        self.assertTrue(isinstance(data, list))
-        # Result data is not empty
-        self.assertTrue(data)
-        self.assertEqual(len(data), 1)
-        item = data[0]
-        self.assertIn('value', item)
-        self.assertIn('label', item)
-        # The label is "first person"
-        self.assertEqual(item['label'], 'fourth person')
-
-    def test_item_unknown(self):
-        response = self.client.get(reverse('url-proxy:item', args=[42]))
-        self.assertEqual(response.status_code, 404)
+RESULT_DICT = [{'value': text(item['pk']), 'label': text(item['name'])} for item in DATABASE]  # noqa
 
 
 @override_settings(
@@ -106,7 +36,7 @@ class AutocompleteUrlSimpleTest(LiveServerTestCase):
 
             self.assertEqual(
                 list(instance.items(query='first')), [
-                    {'value': 1, 'label': 'first person'},
+                    {'value': '1', 'label': 'first person'},
                 ],
             )
             self.assertEqual(
@@ -126,4 +56,31 @@ class AutocompleteUrlSimpleTest(LiveServerTestCase):
             result = instance.selected([searched_id])
             self.assertEqual(result, [
                 (text(searched_id), text('first person'))]
+            )
+
+
+@override_settings(
+    AGNOCOMPLETE_DEFAULT_QUERYSIZE=2,
+    AGNOCOMPLETE_MIN_QUERYSIZE=2,
+    HTTP_HOST='',
+)
+class AutocompleteUrlConvertTest(LiveServerTestCase):
+    """
+    The AutocompleteUrlConvert does not use the same value/label keys.
+    """
+    def test_search(self):
+        instance = AutocompleteUrlConvert()
+        # "mock" Change URL by adding the host
+        search_url = instance.search_url
+        with mock.patch('demo.autocomplete.AutocompleteUrlConvert'
+                        '.get_search_url') as mock_auto:
+            mock_auto.return_value = self.live_server_url + search_url
+            self.assertEqual(
+                list(instance.items(query='person')), RESULT_DICT
+            )
+            # Search for first person
+            self.assertEqual(
+                list(instance.items(query='first')), [
+                    {'value': '1', 'label': 'first person'},
+                ],
             )

--- a/demo/tests/test_url_proxy.py
+++ b/demo/tests/test_url_proxy.py
@@ -15,6 +15,7 @@ from ..autocomplete import (
     AutocompleteUrlConvertComplex,
     AutocompleteUrlSimpleAuth,
     AutocompleteUrlHeadersAuth,
+    AutocompleteUrlSimplePost,
 )
 from .. import DATABASE, GOODAUTHTOKEN
 RESULT_DICT = [{'value': text(item['pk']), 'label': text(item['name'])} for item in DATABASE]  # noqa
@@ -193,3 +194,26 @@ class HTTPErrorHandlingTest(LiveServerTestCase):
                 with self.assertRaises(HTTPError):
                     # Raising a "requests" exception
                     instance.items(query='person')
+
+
+@override_settings(
+    HTTP_HOST='',
+)
+class AutocompleteUrlSimplePostTest(LiveServerTestCase):
+    def test_search(self):
+        instance = AutocompleteUrlSimplePost()
+        # "mock" Change URL by adding the host
+        search_url = instance.search_url
+        with mock.patch('demo.autocomplete.AutocompleteUrlSimplePost'
+                        '.get_search_url') as mock_auto:
+            mock_auto.return_value = self.live_server_url + search_url
+            search_result = instance.items(query='person')
+            self.assertEqual(
+                list(search_result), RESULT_DICT
+            )
+            # Search for first person
+            self.assertEqual(
+                list(instance.items(query='first')), [
+                    {'value': '1', 'label': 'first person'},
+                ],
+            )

--- a/demo/tests/test_url_proxy_views.py
+++ b/demo/tests/test_url_proxy_views.py
@@ -131,3 +131,27 @@ class UrlProxySimpleAuthTest(TestCase):
             {'q': 'person', 'auth_token': GOODAUTHTOKEN}
         )
         self.assertEqual(response.status_code, 200)
+
+
+class UrlProxyHeadersAuthTest(TestCase):
+
+    def test_simple_query_no_auth(self):
+        response = self.client.get(
+            reverse('url-proxy:headers-auth'), {'q': 'person'})
+        self.assertEqual(response.status_code, 403)
+
+    def test_simple_query_wrong_auth(self):
+        response = self.client.get(
+            reverse('url-proxy:headers-auth'),
+            {'q': 'person'},
+            HTTP_X_API_TOKEN='I-AM-WRONG',
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_simple_query_auth(self):
+        response = self.client.get(
+            reverse('url-proxy:headers-auth'),
+            {'q': 'person'},
+            HTTP_X_API_TOKEN=GOODAUTHTOKEN,
+        )
+        self.assertEqual(response.status_code, 200)

--- a/demo/tests/test_url_proxy_views.py
+++ b/demo/tests/test_url_proxy_views.py
@@ -1,0 +1,96 @@
+import json
+
+from django.test import TestCase
+from django.core.urlresolvers import reverse
+
+from ..views_proxy import DATABASE
+
+
+class UrlProxyGenericTest(object):
+
+    @property
+    def http_url(self):
+        raise NotImplementedError("You need a `http_url` property")
+
+    @property
+    def value_key(self):
+        raise NotImplementedError("You need a `value_key` property")
+
+    @property
+    def label_key(self):
+        raise NotImplementedError("You need a `label_key` property")
+
+    def test_simple_query(self):
+        response = self.client.get(self.http_url, {'q': 'person'})
+        self.assertEqual(response.status_code, 200)
+        result = json.loads(response.content.decode())
+        self.assertIn('data', result)
+        data = result['data']
+        # Result data is a list
+        self.assertTrue(isinstance(data, list))
+        # Result data is not empty
+        self.assertTrue(data)
+        self.assertEqual(len(data), len(DATABASE))
+        for item in data:
+            self.assertIn(self.value_key, item)
+            self.assertIn(self.label_key, item)
+            # The label contains "person"
+            self.assertIn('person', item[self.label_key])
+
+    def test_single(self):
+        response = self.client.get(self.http_url, {'q': 'first'})
+        self.assertEqual(response.status_code, 200)
+        result = json.loads(response.content.decode())
+        self.assertIn('data', result)
+        data = result['data']
+        # Result data is a list
+        self.assertTrue(isinstance(data, list))
+        # Result data is not empty
+        self.assertTrue(data)
+        self.assertEqual(len(data), 1)
+
+    def test_empty_query(self):
+        response = self.client.get(self.http_url, {'q': 'lorem ipsum'})
+        self.assertEqual(response.status_code, 200)
+        result = json.loads(response.content.decode())
+        self.assertIn('data', result)
+        data = result['data']
+        # Result data is a list
+        self.assertTrue(isinstance(data, list))
+        # Result data is empty
+        self.assertFalse(data)
+
+
+class UrlProxySimpleTest(UrlProxyGenericTest, TestCase):
+    http_url = reverse('url-proxy:simple')
+    value_key = 'value'
+    label_key = 'label'
+
+
+class UrlProxyConvertTest(UrlProxyGenericTest, TestCase):
+    http_url = reverse('url-proxy:convert')
+    value_key = 'pk'
+    label_key = 'name'
+
+
+class UrlProxyItemTest(TestCase):
+    def test_item(self):
+        response = self.client.get(reverse('url-proxy:item', args=[4]))
+        self.assertEqual(response.status_code, 200)
+        result = json.loads(response.content.decode())
+        self.assertIn('data', result)
+        data = result['data']
+        # Result data is a list
+        self.assertTrue(isinstance(data, list))
+        # Result data is not empty
+        self.assertTrue(data)
+        self.assertEqual(len(data), 1)
+        item = data[0]
+        self.assertIn('value', item)
+        self.assertIn('label', item)
+        # The label is "first person"
+        self.assertEqual(item['label'], 'fourth person')
+
+    def test_item_unknown(self):
+        response = self.client.get(reverse('url-proxy:item', args=[42]))
+        self.assertEqual(response.status_code, 404)

--- a/demo/tests/test_url_proxy_views.py
+++ b/demo/tests/test_url_proxy_views.py
@@ -3,7 +3,7 @@ import json
 from django.test import TestCase
 from django.core.urlresolvers import reverse
 
-from .. import DATABASE
+from .. import DATABASE, GOODAUTHTOKEN
 
 
 class UrlProxyGenericTest(object):
@@ -109,3 +109,25 @@ class UrlProxyItemTest(TestCase):
     def test_item_unknown(self):
         response = self.client.get(reverse('url-proxy:item', args=[42]))
         self.assertEqual(response.status_code, 404)
+
+
+class UrlProxySimpleAuthTest(TestCase):
+
+    def test_simple_query_no_auth(self):
+        response = self.client.get(
+            reverse('url-proxy:simple-auth'), {'q': 'person'})
+        self.assertEqual(response.status_code, 403)
+
+    def test_simple_query_wrong_auth(self):
+        response = self.client.get(
+            reverse('url-proxy:simple-auth'),
+            {'q': 'person', 'auth_token': 'I-AM-WRONG'}
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_simple_query_auth(self):
+        response = self.client.get(
+            reverse('url-proxy:simple-auth'),
+            {'q': 'person', 'auth_token': GOODAUTHTOKEN}
+        )
+        self.assertEqual(response.status_code, 200)

--- a/demo/tests/test_url_proxy_views.py
+++ b/demo/tests/test_url_proxy_views.py
@@ -20,6 +20,10 @@ class UrlProxyGenericTest(object):
     def label_key(self):
         raise NotImplementedError("You need a `label_key` property")
 
+    @property
+    def item_keys(self):
+        return [self.label_key, self.value_key]
+
     def test_simple_query(self):
         response = self.client.get(self.http_url, {'q': 'person'})
         self.assertEqual(response.status_code, 200)
@@ -32,8 +36,8 @@ class UrlProxyGenericTest(object):
         self.assertTrue(data)
         self.assertEqual(len(data), len(DATABASE))
         for item in data:
-            self.assertIn(self.value_key, item)
-            self.assertIn(self.label_key, item)
+            for key in self.item_keys:
+                self.assertIn(key, item)
             # The label contains "person"
             self.assertIn('person', item[self.label_key])
 
@@ -71,6 +75,17 @@ class UrlProxyConvertTest(UrlProxyGenericTest, TestCase):
     http_url = reverse('url-proxy:convert')
     value_key = 'pk'
     label_key = 'name'
+
+
+class UrlProxyConvertComplexTest(UrlProxyGenericTest, TestCase):
+    http_url = reverse('url-proxy:convert-complex')
+    value_key = 'pk'
+    label_key = 'last_name'
+
+    @property
+    def item_keys(self):
+        # Not the same here: the return format is a bit more complex
+        return [self.value_key, 'first_name', 'last_name']
 
 
 class UrlProxyItemTest(TestCase):

--- a/demo/tests/test_url_proxy_views.py
+++ b/demo/tests/test_url_proxy_views.py
@@ -3,7 +3,7 @@ import json
 from django.test import TestCase
 from django.core.urlresolvers import reverse
 
-from ..views_proxy import DATABASE
+from .. import DATABASE
 
 
 class UrlProxyGenericTest(object):

--- a/demo/urls.py
+++ b/demo/urls.py
@@ -50,6 +50,9 @@ urlpatterns = [
         name='url-proxy-simple'),
     url(r'^url-proxy-convert/$', 'demo.views.url_proxy_convert',
         name='url-proxy-convert'),
+    url(r'^url-proxy-convert-complex/$',
+        'demo.views.url_proxy_convert_complex',
+        name='url-proxy-convert-complex'),
 
     # Mock Third Party URLs
     url(r'^3rdparty/', include('demo.urls_proxy', namespace='url-proxy')),

--- a/demo/urls.py
+++ b/demo/urls.py
@@ -53,6 +53,8 @@ urlpatterns = [
     url(r'^url-proxy-convert-complex/$',
         'demo.views.url_proxy_convert_complex',
         name='url-proxy-convert-complex'),
+    url(r'^url-proxy-auth/$', 'demo.views.url_proxy_auth',
+        name='url-proxy-auth'),
 
     # Mock Third Party URLs
     url(r'^3rdparty/', include('demo.urls_proxy', namespace='url-proxy')),

--- a/demo/urls.py
+++ b/demo/urls.py
@@ -5,6 +5,7 @@ from django.conf.urls import include, url
 from django.contrib import admin
 
 from agnocomplete import get_namespace
+from . import views
 
 
 urlpatterns = [
@@ -20,37 +21,41 @@ urlpatterns = [
     ),
 
     # Agnocomplete Custom view
-    url(r'^hidden-autocomplete/$', 'demo.views.hidden_autocomplete',
+    url(r'^hidden-autocomplete/$', views.hidden_autocomplete,
         name='hidden-autocomplete'),
 
     # Templated DEMO views
-    url(r'^$', 'demo.views.index', name='home'),
-    url(r'^filled-form/$', 'demo.views.filled_form', name='filled-form'),
-    url(r'^search-context/$', 'demo.views.search_context', name='search-context'),  # noqa
-    url(r'^custom/$', 'demo.views.search_custom', name='search-custom'),
+    url(r'^$', views.index, name='home'),
+    url(r'^filled-form/$', views.filled_form, name='filled-form'),
+    url(r'^search-context/$', views.search_context, name='search-context'),
+    url(r'^custom/$', views.search_custom, name='search-custom'),
     # Demo Front JS views
-    url(r'^selectize/$', 'demo.views.selectize', name='selectize'),
-    url(r'^selectize-extra/$', 'demo.views.selectize_extra', name='selectize-extra'),  # noqa
-    url(r'^selectize-multi/$', 'demo.views.selectize_multi', name='selectize-multi'),  # noqa
-    url(r'^selectize-tag/$', 'demo.views.selectize_tag', name='selectize-tag'),
-    url(r'^selectize-model-tag/$', 'demo.views.selectize_model_tag', name='selectize-model-tag'),  # noqa
+    url(r'^selectize/$', views.selectize, name='selectize'),
+    url(r'^selectize-extra/$', views.selectize_extra, name='selectize-extra'),
+    url(r'^selectize-multi/$', views.selectize_multi, name='selectize-multi'),
+    url(r'^selectize-tag/$', views.selectize_tag, name='selectize-tag'),
+    url(r'^selectize-model-tag/$',
+        views.selectize_model_tag, name='selectize-model-tag'),
     url(r'^selectize-model-tag/edit/(?P<pk>\d+)/$',
-        'demo.views.selectize_model_tag_edit',
-        name='selectize-model-tag-edit'),  # noqa
-    url(r'^selectize-model-tag-with-create/$', 'demo.views.selectize_model_tag_with_create', name='selectize-model-tag-with-create'),  # noqa
-    url(r'^selectize-context-tag/$', 'demo.views.selectize_context_tag', name='selectize-context-tag'),  # noqa
+        views.selectize_model_tag_edit,
+        name='selectize-model-tag-edit'),
+    url(r'^selectize-model-tag-with-create/$',
+        views.selectize_model_tag_with_create,
+        name='selectize-model-tag-with-create'),
+    url(r'^selectize-context-tag/$',
+        views.selectize_context_tag, name='selectize-context-tag'),
     # Select 2, jquery-autocomplete, typeahead
-    url(r'^select2/$', 'demo.views.select2', name='select2'),
-    url(r'^jquery-autocomplete/$', 'demo.views.jquery_autocomplete',
+    url(r'^select2/$', views.select2, name='select2'),
+    url(r'^jquery-autocomplete/$', views.jquery_autocomplete,
         name='jquery-autocomplete'),
-    url(r'^typeahead/$', 'demo.views.typeahead', name='typeahead'),
+    url(r'^typeahead/$', views.typeahead, name='typeahead'),
 
     # URL Proxy Urls
-    url(r'^url-proxy-simple/$', 'demo.views.url_proxy_simple',
+    url(r'^url-proxy-simple/$', views.url_proxy_simple,
         name='url-proxy-simple'),
-    url(r'^url-proxy-convert/$', 'demo.views.url_proxy_convert',
+    url(r'^url-proxy-convert/$', views.url_proxy_convert,
         name='url-proxy-convert'),
-    url(r'^url-proxy-auth/$', 'demo.views.url_proxy_auth',
+    url(r'^url-proxy-auth/$', views.url_proxy_auth,
         name='url-proxy-auth'),
 
     # Mock Third Party URLs

--- a/demo/urls.py
+++ b/demo/urls.py
@@ -50,9 +50,6 @@ urlpatterns = [
         name='url-proxy-simple'),
     url(r'^url-proxy-convert/$', 'demo.views.url_proxy_convert',
         name='url-proxy-convert'),
-    url(r'^url-proxy-convert-complex/$',
-        'demo.views.url_proxy_convert_complex',
-        name='url-proxy-convert-complex'),
     url(r'^url-proxy-auth/$', 'demo.views.url_proxy_auth',
         name='url-proxy-auth'),
 

--- a/demo/urls.py
+++ b/demo/urls.py
@@ -45,7 +45,8 @@ urlpatterns = [
         name='jquery-autocomplete'),
     url(r'^typeahead/$', 'demo.views.typeahead', name='typeahead'),
 
-    url(r'^url-proxy-simple', 'demo.views.url_proxy_simple',
+    # URL Proxy Urls
+    url(r'^url-proxy-simple/$', 'demo.views.url_proxy_simple',
         name='url-proxy-simple'),
 
     # Mock Third Party URLs

--- a/demo/urls.py
+++ b/demo/urls.py
@@ -44,4 +44,11 @@ urlpatterns = [
     url(r'^jquery-autocomplete/$', 'demo.views.jquery_autocomplete',
         name='jquery-autocomplete'),
     url(r'^typeahead/$', 'demo.views.typeahead', name='typeahead'),
+
+    url(r'^url-proxy-simple', 'demo.views.url_proxy_simple',
+        name='url-proxy-simple'),
+
+    # Mock Third Party URLs
+    url(r'^3rdparty/', include('demo.urls_proxy', namespace='url-proxy')),
+
 ]

--- a/demo/urls.py
+++ b/demo/urls.py
@@ -48,6 +48,8 @@ urlpatterns = [
     # URL Proxy Urls
     url(r'^url-proxy-simple/$', 'demo.views.url_proxy_simple',
         name='url-proxy-simple'),
+    url(r'^url-proxy-convert/$', 'demo.views.url_proxy_convert',
+        name='url-proxy-convert'),
 
     # Mock Third Party URLs
     url(r'^3rdparty/', include('demo.urls_proxy', namespace='url-proxy')),

--- a/demo/urls_proxy.py
+++ b/demo/urls_proxy.py
@@ -9,4 +9,6 @@ urlpatterns = [
     url(r'^item/(?P<pk>[0-9]+)$', views_proxy.item, name='item'),
     url(r'^simple/$', views_proxy.simple, name='simple'),
     url(r'^convert/$', views_proxy.convert, name='convert'),
+    url(r'^convert-complex/$',
+        views_proxy.convert_complex, name='convert-complex'),
 ]

--- a/demo/urls_proxy.py
+++ b/demo/urls_proxy.py
@@ -8,6 +8,7 @@ from . import views_proxy
 urlpatterns = [
     url(r'^item/(?P<pk>[0-9]+)$', views_proxy.item, name='item'),
     url(r'^simple/$', views_proxy.simple, name='simple'),
+    url(r'^simple-post/$', views_proxy.simple_post, name='simple-post'),
     url(r'^convert/$', views_proxy.convert, name='convert'),
     url(r'^convert-complex/$',
         views_proxy.convert_complex, name='convert-complex'),

--- a/demo/urls_proxy.py
+++ b/demo/urls_proxy.py
@@ -6,5 +6,6 @@ from . import views_proxy
 
 
 urlpatterns = [
+    url(r'^item/(?P<pk>[0-9]+)$', views_proxy.item, name='item'),
     url(r'^simple/$', views_proxy.simple, name='simple'),
 ]

--- a/demo/urls_proxy.py
+++ b/demo/urls_proxy.py
@@ -11,4 +11,5 @@ urlpatterns = [
     url(r'^convert/$', views_proxy.convert, name='convert'),
     url(r'^convert-complex/$',
         views_proxy.convert_complex, name='convert-complex'),
+    url(r'^simple-auth/$', views_proxy.simple_auth, name='simple-auth'),
 ]

--- a/demo/urls_proxy.py
+++ b/demo/urls_proxy.py
@@ -12,4 +12,5 @@ urlpatterns = [
     url(r'^convert-complex/$',
         views_proxy.convert_complex, name='convert-complex'),
     url(r'^simple-auth/$', views_proxy.simple_auth, name='simple-auth'),
+    url(r'^headers-auth/$', views_proxy.headers_auth, name='headers-auth'),
 ]

--- a/demo/urls_proxy.py
+++ b/demo/urls_proxy.py
@@ -8,4 +8,5 @@ from . import views_proxy
 urlpatterns = [
     url(r'^item/(?P<pk>[0-9]+)$', views_proxy.item, name='item'),
     url(r'^simple/$', views_proxy.simple, name='simple'),
+    url(r'^convert/$', views_proxy.convert, name='convert'),
 ]

--- a/demo/urls_proxy.py
+++ b/demo/urls_proxy.py
@@ -1,0 +1,10 @@
+"""
+Demo URL Configuration
+"""
+from django.conf.urls import url
+from . import views_proxy
+
+
+urlpatterns = [
+    url(r'^simple/$', views_proxy.simple, name='simple'),
+]

--- a/demo/views.py
+++ b/demo/views.py
@@ -17,7 +17,8 @@ from .forms import (
     PersonTagForm, PersonTagModelForm,
     PersonTagModelFormWithCreate,
     PersonContextTagModelForm,
-    UrlProxyForm, UrlProxyConvertForm, UrlProxyConvertComplexForm
+    UrlProxyForm, UrlProxyConvertForm, UrlProxyConvertComplexForm,
+    UrlProxyAuthForm,
 )
 from .autocomplete import HiddenAutocomplete
 from .models import PersonTag
@@ -190,6 +191,12 @@ class UrlProxyConvertComplexView(AutoView):
     template_name = "selectize.html"
 
 
+class UrlProxyAuthView(AutoView):
+    form_class = UrlProxyAuthForm
+    title = 'Authenticated URLs, returned normal data'
+    template_name = "selectize.html"
+
+
 index = IndexView.as_view()
 filled_form = FilledFormView.as_view()
 search_context = SearchContextFormView.as_view()
@@ -213,3 +220,4 @@ selectize_context_tag = PersonContextTagView.as_view()
 url_proxy_simple = UrlProxySimpleView.as_view()
 url_proxy_convert = UrlProxyConvertView.as_view()
 url_proxy_convert_complex = UrlProxyConvertComplexView.as_view()
+url_proxy_auth = UrlProxyAuthView.as_view()

--- a/demo/views.py
+++ b/demo/views.py
@@ -17,7 +17,7 @@ from .forms import (
     PersonTagForm, PersonTagModelForm,
     PersonTagModelFormWithCreate,
     PersonContextTagModelForm,
-    UrlProxyForm, UrlProxyConvertForm, UrlProxyConvertComplexForm,
+    UrlProxyForm, UrlProxyConvertForm,
     UrlProxyAuthForm,
 )
 from .autocomplete import HiddenAutocomplete
@@ -181,13 +181,7 @@ class UrlProxySimpleView(AutoView):
 
 class UrlProxyConvertView(AutoView):
     form_class = UrlProxyConvertForm
-    title = 'Simple URL, returned data with little transformation'
-    template_name = "selectize.html"
-
-
-class UrlProxyConvertComplexView(AutoView):
-    form_class = UrlProxyConvertComplexForm
-    title = 'Simple URL, returned data with a big transormation'
+    title = 'Converted data when returned, more or less mangled'
     template_name = "selectize.html"
 
 
@@ -219,5 +213,4 @@ selectize_context_tag = PersonContextTagView.as_view()
 # URL proxies
 url_proxy_simple = UrlProxySimpleView.as_view()
 url_proxy_convert = UrlProxyConvertView.as_view()
-url_proxy_convert_complex = UrlProxyConvertComplexView.as_view()
 url_proxy_auth = UrlProxyAuthView.as_view()

--- a/demo/views.py
+++ b/demo/views.py
@@ -17,7 +17,7 @@ from .forms import (
     PersonTagForm, PersonTagModelForm,
     PersonTagModelFormWithCreate,
     PersonContextTagModelForm,
-    UrlProxyForm, UrlProxyConvertForm
+    UrlProxyForm, UrlProxyConvertForm, UrlProxyConvertComplexForm
 )
 from .autocomplete import HiddenAutocomplete
 from .models import PersonTag
@@ -184,6 +184,12 @@ class UrlProxyConvertView(AutoView):
     template_name = "selectize.html"
 
 
+class UrlProxyConvertComplexView(AutoView):
+    form_class = UrlProxyConvertComplexForm
+    title = 'Simple URL, returned data with a big transormation'
+    template_name = "selectize.html"
+
+
 index = IndexView.as_view()
 filled_form = FilledFormView.as_view()
 search_context = SearchContextFormView.as_view()
@@ -203,5 +209,7 @@ selectize_model_tag = PersonTagModelView.as_view()
 selectize_model_tag_edit = PersonTagModelViewEdit.as_view()
 selectize_model_tag_with_create = PersonTagModelViewWithCreate.as_view()
 selectize_context_tag = PersonContextTagView.as_view()
+# URL proxies
 url_proxy_simple = UrlProxySimpleView.as_view()
 url_proxy_convert = UrlProxyConvertView.as_view()
+url_proxy_convert_complex = UrlProxyConvertComplexView.as_view()

--- a/demo/views.py
+++ b/demo/views.py
@@ -17,6 +17,7 @@ from .forms import (
     PersonTagForm, PersonTagModelForm,
     PersonTagModelFormWithCreate,
     PersonContextTagModelForm,
+    UrlProxyForm,
 )
 from .autocomplete import HiddenAutocomplete
 from .models import PersonTag
@@ -171,6 +172,12 @@ class PersonContextTagView(AutoTitleMixin,
         return reverse('home')
 
 
+class UrlProxySimpleView(AutoView):
+    form_class = UrlProxyForm
+    title = 'Simple URL, returned data without transformation'
+    template_name = "selectize.html"
+
+
 index = IndexView.as_view()
 filled_form = FilledFormView.as_view()
 search_context = SearchContextFormView.as_view()
@@ -190,3 +197,4 @@ selectize_model_tag = PersonTagModelView.as_view()
 selectize_model_tag_edit = PersonTagModelViewEdit.as_view()
 selectize_model_tag_with_create = PersonTagModelViewWithCreate.as_view()
 selectize_context_tag = PersonContextTagView.as_view()
+url_proxy_simple = UrlProxySimpleView.as_view()

--- a/demo/views.py
+++ b/demo/views.py
@@ -17,7 +17,7 @@ from .forms import (
     PersonTagForm, PersonTagModelForm,
     PersonTagModelFormWithCreate,
     PersonContextTagModelForm,
-    UrlProxyForm,
+    UrlProxyForm, UrlProxyConvertForm
 )
 from .autocomplete import HiddenAutocomplete
 from .models import PersonTag
@@ -178,6 +178,12 @@ class UrlProxySimpleView(AutoView):
     template_name = "selectize.html"
 
 
+class UrlProxyConvertView(AutoView):
+    form_class = UrlProxyConvertForm
+    title = 'Simple URL, returned data with little transformation'
+    template_name = "selectize.html"
+
+
 index = IndexView.as_view()
 filled_form = FilledFormView.as_view()
 search_context = SearchContextFormView.as_view()
@@ -198,3 +204,4 @@ selectize_model_tag_edit = PersonTagModelViewEdit.as_view()
 selectize_model_tag_with_create = PersonTagModelViewWithCreate.as_view()
 selectize_context_tag = PersonContextTagView.as_view()
 url_proxy_simple = UrlProxySimpleView.as_view()
+url_proxy_convert = UrlProxyConvertView.as_view()

--- a/demo/views_proxy.py
+++ b/demo/views_proxy.py
@@ -1,6 +1,7 @@
 import json
 
-from django.http import HttpResponse
+from django.http import HttpResponse, Http404
+from django.utils.encoding import force_text as text
 from django.views.decorators.http import require_GET
 
 # This is your fake DB
@@ -15,13 +16,28 @@ DATABASE = (
 )
 
 
+def convert_data(item):
+    return {'value': item['pk'], 'label': item['name']}
+
+
 @require_GET
 def simple(request):
     search_term = request.GET.get('q', None)
     data = []
     if search_term:
-        raw = filter(lambda x: search_term in x['name'], DATABASE)
-        for item in raw:
-            data.append({'value': item['pk'], 'label': item['name']})
+        data = filter(lambda x: search_term in x['name'], DATABASE)
+    data = map(convert_data, data)
+    data = list(data)
+    result = {'data': data}
+    return HttpResponse(json.dumps(result))
+
+
+@require_GET
+def item(request, pk):
+    data = filter(lambda item: text(item['pk']) == text(pk), DATABASE)
+    data = map(convert_data, data)
+    data = list(data)
+    if not data:
+        raise Http404("Unknown item `{}`".format(pk))
     result = {'data': data}
     return HttpResponse(json.dumps(result))

--- a/demo/views_proxy.py
+++ b/demo/views_proxy.py
@@ -1,11 +1,12 @@
 import json
 import logging
 
+from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse, Http404
 from django.utils.encoding import force_text as text
 from django.views.decorators.http import require_GET
 
-from . import DATABASE
+from . import DATABASE, GOODAUTHTOKEN
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +64,21 @@ def convert_complex(request, *args, **kwargs):
     result = _search(search_term, convert_data_complex)
     response = json.dumps(result)
     logger.debug('3rd party complex conversion search: `%s`', search_term)
+    logger.debug('response: `%s`', response)
+    return HttpResponse(response)
+
+
+@require_GET
+def simple_auth(request, *args, **kwargs):
+    # Check authentication
+    auth_token = request.GET.get('auth_token', None)
+    if not auth_token or auth_token != GOODAUTHTOKEN:
+        logger.error('Error: Failed authentication')
+        raise PermissionDenied("Failed Authentication")
+    search_term = request.GET.get('q', None)
+    result = _search(search_term, convert_data)
+    response = json.dumps(result)
+    logger.debug('3rd party simple search: `%s`', search_term)
     logger.debug('response: `%s`', response)
     return HttpResponse(response)
 

--- a/demo/views_proxy.py
+++ b/demo/views_proxy.py
@@ -20,15 +20,29 @@ def convert_data(item):
     return {'value': item['pk'], 'label': item['name']}
 
 
-@require_GET
-def simple(request):
-    search_term = request.GET.get('q', None)
+def _search(search_term, convert=True):
     data = []
     if search_term:
         data = filter(lambda x: search_term in x['name'], DATABASE)
-    data = map(convert_data, data)
+    if convert:
+        data = map(convert_data, data)
     data = list(data)
     result = {'data': data}
+    return result
+
+
+@require_GET
+def simple(request):
+    search_term = request.GET.get('q', None)
+    result = _search(search_term)
+    return HttpResponse(json.dumps(result))
+
+
+@require_GET
+def convert(request):
+    search_term = request.GET.get('q', None)
+    # Fetching result without converting item JSON payload.
+    result = _search(search_term, False)
     return HttpResponse(json.dumps(result))
 
 

--- a/demo/views_proxy.py
+++ b/demo/views_proxy.py
@@ -4,7 +4,7 @@ import logging
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse, Http404
 from django.utils.encoding import force_text as text
-from django.views.decorators.http import require_GET
+from django.views.decorators.http import require_GET, require_POST
 
 from . import DATABASE, GOODAUTHTOKEN
 
@@ -94,6 +94,16 @@ def headers_auth(request, *args, **kwargs):
     result = _search(search_term, convert_data)
     response = json.dumps(result)
     logger.debug('3rd party simple search: `%s`', search_term)
+    logger.debug('response: `%s`', response)
+    return HttpResponse(response)
+
+
+@require_POST
+def simple_post(request, *args, **kwargs):
+    search_term = request.POST.get('q', None)
+    result = _search(search_term, convert_data)
+    response = json.dumps(result)
+    logger.debug('3rd party POST search: `%s`', search_term)
     logger.debug('response: `%s`', response)
     return HttpResponse(response)
 

--- a/demo/views_proxy.py
+++ b/demo/views_proxy.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 from django.http import HttpResponse, Http404
 from django.utils.encoding import force_text as text
@@ -6,35 +7,64 @@ from django.views.decorators.http import require_GET
 
 from . import DATABASE
 
+logger = logging.getLogger(__name__)
+
 
 def convert_data(item):
     return {'value': item['pk'], 'label': item['name']}
 
 
-def _search(search_term, convert=True):
+def convert_data_complex(item):
+    first, last = item['name'].split(' ')
+    return {
+        'pk': item['pk'],
+        'first_name': first,
+        'last_name': last,
+    }
+
+
+def _search(search_term, convert_func):
     data = []
     if search_term:
         data = filter(lambda x: search_term in x['name'], DATABASE)
-    if convert:
-        data = map(convert_data, data)
+    if data and convert_func:
+        data = map(convert_func, data)
     data = list(data)
     result = {'data': data}
     return result
 
 
 @require_GET
-def simple(request):
+def simple(request, *args, **kwargs):
     search_term = request.GET.get('q', None)
-    result = _search(search_term)
-    return HttpResponse(json.dumps(result))
+    result = _search(search_term, convert_data)
+    response = json.dumps(result)
+    logger.debug('3rd party simple search: `%s`', search_term)
+    logger.debug('response: `%s`', response)
+    return HttpResponse(response)
 
 
 @require_GET
-def convert(request):
+def convert(request, *args, **kwargs):
+    search_term = request.GET.get('q', None)
+    # Fetching result and not converting the item JSON payload.
+    # i.e.: leaving the pk/name labels.
+    result = _search(search_term, None)
+    response = json.dumps(result)
+    logger.debug('3rd party converted search: `%s`', search_term)
+    logger.debug('response: `%s`', response)
+    return HttpResponse(response)
+
+
+@require_GET
+def convert_complex(request, *args, **kwargs):
     search_term = request.GET.get('q', None)
     # Fetching result without converting item JSON payload.
-    result = _search(search_term, False)
-    return HttpResponse(json.dumps(result))
+    result = _search(search_term, convert_data_complex)
+    response = json.dumps(result)
+    logger.debug('3rd party complex conversion search: `%s`', search_term)
+    logger.debug('response: `%s`', response)
+    return HttpResponse(response)
 
 
 @require_GET
@@ -42,7 +72,10 @@ def item(request, pk):
     data = filter(lambda item: text(item['pk']) == text(pk), DATABASE)
     data = map(convert_data, data)
     data = list(data)
+    logger.debug('3rd item search: `%s`', pk)
     if not data:
         raise Http404("Unknown item `{}`".format(pk))
     result = {'data': data}
-    return HttpResponse(json.dumps(result))
+    response = json.dumps(result)
+    logger.debug('response: `%s`', response)
+    return HttpResponse(response)

--- a/demo/views_proxy.py
+++ b/demo/views_proxy.py
@@ -1,0 +1,27 @@
+import json
+
+from django.http import HttpResponse
+from django.views.decorators.http import require_GET
+
+# This is your fake DB
+DATABASE = (
+    {"pk": 1, 'name': 'first person'},
+    {"pk": 2, 'name': 'second person'},
+    {"pk": 3, 'name': 'third person'},
+    {"pk": 4, 'name': 'fourth person'},
+    {"pk": 5, 'name': 'fifth person'},
+    {"pk": 6, 'name': 'sixth person'},
+    {"pk": 7, 'name': 'seventh person'},
+)
+
+
+@require_GET
+def simple(request):
+    search_term = request.GET.get('q', None)
+    data = []
+    if search_term:
+        raw = filter(lambda x: search_term in x['name'], DATABASE)
+        for item in raw:
+            data.append({'value': item['pk'], 'label': item['name']})
+    result = {'data': data}
+    return HttpResponse(json.dumps(result))

--- a/demo/views_proxy.py
+++ b/demo/views_proxy.py
@@ -4,16 +4,7 @@ from django.http import HttpResponse, Http404
 from django.utils.encoding import force_text as text
 from django.views.decorators.http import require_GET
 
-# This is your fake DB
-DATABASE = (
-    {"pk": 1, 'name': 'first person'},
-    {"pk": 2, 'name': 'second person'},
-    {"pk": 3, 'name': 'third person'},
-    {"pk": 4, 'name': 'fourth person'},
-    {"pk": 5, 'name': 'fifth person'},
-    {"pk": 6, 'name': 'sixth person'},
-    {"pk": 7, 'name': 'seventh person'},
-)
+from . import DATABASE
 
 
 def convert_data(item):

--- a/demo/views_proxy.py
+++ b/demo/views_proxy.py
@@ -84,6 +84,21 @@ def simple_auth(request, *args, **kwargs):
 
 
 @require_GET
+def headers_auth(request, *args, **kwargs):
+    # Check authentication
+    auth_token = request.META.get('HTTP_X_API_TOKEN', None)
+    if not auth_token or auth_token != GOODAUTHTOKEN:
+        logger.error('Error: Failed authentication')
+        raise PermissionDenied("Failed Authentication")
+    search_term = request.GET.get('q', None)
+    result = _search(search_term, convert_data)
+    response = json.dumps(result)
+    logger.debug('3rd party simple search: `%s`', search_term)
+    logger.debug('response: `%s`', response)
+    return HttpResponse(response)
+
+
+@require_GET
 def item(request, pk):
     data = filter(lambda item: text(item['pk']) == text(pk), DATABASE)
     data = map(convert_data, data)

--- a/docs/autocomplete-definition.rst
+++ b/docs/autocomplete-definition.rst
@@ -229,6 +229,8 @@ You may want to add extra fields to your returned records, fields that belong to
 Extra arguments
 ===============
 
+.. versionadded:: 0.6
+
 Your front-end code may send you extra arguments that are not covered by the standard interface definition. These arguments will be passed down to your ``Agnocomplete`` class and can be used in the :meth:`items()` or the :meth:`get_dataset()` methods.
 
 .. code-block:: python
@@ -263,6 +265,8 @@ Everything is possible in the view: you can even push your custom arguments, bas
 
 Using Extra arguments with Models/Querysets
 -------------------------------------------
+
+.. versionadded:: 0.6
 
 In the case of a queryset-based Agnocomplete, you can also use the extra arguments in the ``Agnocomplete`` class.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,7 @@ So far, we've got it implemented using:
    overview
    autocomplete-definition
    context-dependant-completions
+   url-proxy
    custom-views
    fields-widgets
    demo-site

--- a/docs/url-proxy.rst
+++ b/docs/url-proxy.rst
@@ -13,7 +13,7 @@ Example:
     from agnocomplete.core import AgnocompleteUrlProxy
 
     class ServiceAutocomplete(AgnocompleteUrlProxy):
-        search_url = "https://api.example.com/search?q={q}"
+        search_url = "https://api.example.com/search"
         item_url = "https://api.example.com/item/{id}"
 
 You may want to have either a :meth:`get_search_url()` method in your class, or overriding the ``search_url`` property.
@@ -100,7 +100,7 @@ The :meth:`get_http_call_kwargs()` method is completely overridable like this:
 .. code-block:: python
 
     class AutocompleteUrlExtraArgs(AgnocompleteProxy):
-        search_url = 'http://api.examplecom/search?q={q}&auth_token={auth_token}'
+        search_url = 'http://api.example.com/search'
 
         def get_http_call_kwargs(self, query):
             query_args = super(
@@ -131,10 +131,23 @@ By default, this method returns an empty dictionary, so you can completely scrat
 .. code-block:: python
 
     class AutocompleteUrlExtraHeaders(AgnocompleteProxy):
-        search_url = 'http://api.examplecom/search?q={q}'
+        search_url = 'http://api.example.com/search'
 
         def get_http_headers(self):
             return {
                 'X-API-TOKEN': 'GOODAUTHTOKEN',
                 'Content-type': 'application/json',
             }
+
+GET or POST
+-----------
+
+The default HTTP verb used is ``GET``, but you may be forced to use ``POST`` if your 3rd party API wants you to. It's just one configuration flag here:
+
+.. code-block:: python
+
+    class AutocompleteUrlPost(AgnocompleteProxy):
+        search_url = 'http://api.example.com/search'
+        method = 'post'
+
+The payload (with or without extra arguments) will be sent as a JSON dictionary.

--- a/docs/url-proxy.rst
+++ b/docs/url-proxy.rst
@@ -76,7 +76,7 @@ If the returned JSON is in now way similar to what you were expecting, you have 
                 value=current_item['pk'],
                 label='{} {}'.format(current_item['first_name'], current_item['last_name']),
             )
-    
+
 
 or, if things are going more complicated:
 
@@ -89,3 +89,33 @@ or, if things are going more complicated:
                 value=current_item[current_item['meta']['value_field']],
                 label='{} {}'.format(current_item['label1'], current_item['label2']),
             )
+
+Passing extra arguments to the API
+----------------------------------
+
+For various reasons (mostly authentication), you may need to pass extra arguments to the 3rd party API.
+
+The :meth:`get_http_call_kwargs()` method is completely overridable like this:
+
+.. code-block:: python
+
+    class AutocompleteUrlExtraArgs(AgnocompleteProxy):
+        search_url = 'http://api.examplecom/search?q={q}&auth_token={auth_token}'
+
+        def get_http_call_kwargs(self, query):
+            query_args = super(
+                AutocompleteUrlExtraArgs, self).get_http_call_kwargs(query)
+            query_args['auth_token'] = 'GOODAUTHTOKEN'
+            return query_args
+
+.. note::
+
+    You may want to change here the default name of the search term field, if the 3rd party API doesn't accept "q" as a search term name.
+
+    .. code-block:: python
+
+        def get_http_call_kwargs(self, query):
+            return {
+                'search': query,
+                'auth_token': 'GOODAUTHTOKEN',
+            }

--- a/docs/url-proxy.rst
+++ b/docs/url-proxy.rst
@@ -33,3 +33,28 @@ What if it doesn't return the standard agnocomplete JSON?
 ---------------------------------------------------------
 
 You'll have to convert this data into a format known by the agnocomplete widgets. Hopefully, we're providing simple parameters to make an easy conversion.
+
+What's configurable?
+
+* ``value_key``: the name of the key in the item dictionary to be used for ``value``,
+* ``label_key``: the name of the key in the item dictionary to be used for ``label``,
+
+Example:
+
+.. code-block:: python
+
+    class AutocompleteUrlConvert(AgnocompleteUrlProxy):
+        value_key = 'pk'
+        label_key = 'full_name'
+
+With this class, the item:
+
+.. code-block:: json
+
+    {"pk": 19911, "full_name": "Inigo Montoya", "country": "Spain"}
+
+will be converted like this before being returned by the search:
+
+.. code-block:: json
+
+    {"value": 19911, "label": "Inigo Montoya"}

--- a/docs/url-proxy.rst
+++ b/docs/url-proxy.rst
@@ -1,0 +1,35 @@
+==================================
+Autocompletion via a 3rd party URL
+==================================
+
+.. versionadded:: 0.6
+
+This features gives you the opportunity to create an autocompletion field that fetches its data from a 3rd party library (typically a REST or an HTTP API).
+
+Example:
+
+.. code-block:: python
+
+    from agnocomplete.core import AgnocompleteUrlProxy
+
+    class ServiceAutocomplete(AgnocompleteUrlProxy):
+        search_url = "https://api.example.com/search?q={q}"
+        item_url = "https://api.example.com/item/{id}"
+
+You may want to have either a :meth:`get_search_url()` method in your class, or overriding the ``search_url`` property.
+
+Also, the ``item_url`` can be overridden by a :meth:`get_item_url()` method.
+
+These must be an accessible full-URL (including scheme, domain, and port if necessary) with at least one search term variable to inject in the URL for searching it.
+
+If you're lucky enough, this target URL respects:
+
+* the agnocomplete return data schema,
+* the agnocomplete query argument list (q, page_size, etc).
+
+then, you won't have to do anything else: this service will return data directly usable with your favorite HTML/JS tool.
+
+What if it doesn't return the standard agnocomplete JSON?
+---------------------------------------------------------
+
+You'll have to convert this data into a format known by the agnocomplete widgets. Hopefully, we're providing simple parameters to make an easy conversion.

--- a/docs/url-proxy.rst
+++ b/docs/url-proxy.rst
@@ -35,6 +35,7 @@ What if it doesn't return the standard agnocomplete JSON?
 You'll have to convert this data into a format known by the agnocomplete widgets. Hopefully, we're providing simple parameters to make an easy conversion.
 
 What's configurable?
+++++++++++++++++++++
 
 * ``value_key``: the name of the key in the item dictionary to be used for ``value``,
 * ``label_key``: the name of the key in the item dictionary to be used for ``label``,
@@ -58,3 +59,33 @@ will be converted like this before being returned by the search:
 .. code-block:: json
 
     {"value": 19911, "label": "Inigo Montoya"}
+
+For more complicated cases
+++++++++++++++++++++++++++
+
+If the returned JSON is in now way similar to what you were expecting, you have several options:
+
+**If the JSON is a list or an iterable**, you can override the `Agnocomplete` class :meth:`item()` method, like this:
+
+.. code-block:: python
+
+    class AutocompleteUrlConvert(AgnocompleteUrlProxy):
+
+        def item(self, current_item):
+            return dict(
+                value=current_item['pk'],
+                label='{} {}'.format(current_item['first_name'], current_item['last_name']),
+            )
+    
+
+or, if things are going more complicated:
+
+.. code-block:: python
+
+    class AutocompleteUrlConvert(AgnocompleteUrlProxy):
+
+        def item(self, current_item):
+            return dict(
+                value=current_item[current_item['meta']['value_field']],
+                label='{} {}'.format(current_item['label1'], current_item['label2']),
+            )

--- a/docs/url-proxy.rst
+++ b/docs/url-proxy.rst
@@ -90,8 +90,8 @@ or, if things are going more complicated:
                 label='{} {}'.format(current_item['label1'], current_item['label2']),
             )
 
-Passing extra arguments to the API
-----------------------------------
+Passing extra arguments to the API call
+---------------------------------------
 
 For various reasons (mostly authentication), you may need to pass extra arguments to the 3rd party API.
 
@@ -118,4 +118,23 @@ The :meth:`get_http_call_kwargs()` method is completely overridable like this:
             return {
                 'search': query,
                 'auth_token': 'GOODAUTHTOKEN',
+            }
+
+Adding headers to the HTTP call
+-------------------------------
+
+You also may want to add custom HTTP headers to your request to the 3rd party API. For authentication reasons, or if you need to specify a Content-type, etc.
+In order to do so, you can override the :meth:`get_http_headers()` method in the Agnocomplete class.
+
+By default, this method returns an empty dictionary, so you can completely scratch it, no offense.
+
+.. code-block:: python
+
+    class AutocompleteUrlExtraHeaders(AgnocompleteProxy):
+        search_url = 'http://api.examplecom/search?q={q}'
+
+        def get_http_headers(self):
+            return {
+                'X-API-TOKEN': 'GOODAUTHTOKEN',
+                'Content-type': 'application/json',
             }

--- a/requirements-test.pip
+++ b/requirements-test.pip
@@ -1,1 +1,2 @@
 PyYAML
+mock

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,2 +1,3 @@
 Django>=1.8.0,<1.10
 six
+requests

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     license='MIT',
     install_requires=[
         'Django',
-        'six'
+        'six',
+        'requests',
     ],
 )


### PR DESCRIPTION
refs #59
- no more "literal strings" in URL definitions, but a callable,
- do not use the urlpattern function
