### PR TITLE
add a `get_http_result` method to reflow API data into a usable dataset

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ master (unreleased)
 - Dropped support for Django 1.6 / 1.7 (#54),
 - Added support for Django 1.9. Please note that the combination Python 3.3 and Django 1.9 is incompatible - `see Django 1.9 release notes <https://docs.djangoproject.com/en/1.10/releases/1.9/>`_ (#56).
 - Added support for extra arguments passed to the search URL, passed on the Agnocomplete class (#52).
-- Added the ``AgnocompleteUrlProxy`` class, handling autocomplete using a third-party HTTP API (#55).
+- Added the ``AgnocompleteUrlProxy`` class, handling autocomplete using a third-party HTTP API (#55, #62).
 - Removed Django 1.10 deprecation warnings (#59).
 
 0.5.0 (2016-07-01)

--- a/demo/autocomplete.py
+++ b/demo/autocomplete.py
@@ -177,6 +177,34 @@ class AutocompleteUrlConvert(AutocompleteUrlMixin):
         )
 
 
+class AutocompleteUrlConvertSchema(AutocompleteUrlMixin):
+    """
+    Return results embedded under the "result" key.
+    """
+    data_key = 'result'
+
+    def get_search_url(self):
+        return '{}{}'.format(
+            getattr(settings, 'HTTP_HOST', ''),
+            reverse_lazy('url-proxy:convert-schema'),
+        )
+
+
+class AutocompleteUrlConvertSchemaList(AutocompleteUrlMixin):
+    """
+    Return results as a list, not a dict
+    """
+    def get_search_url(self):
+        return '{}{}'.format(
+            getattr(settings, 'HTTP_HOST', ''),
+            reverse_lazy('url-proxy:convert-schema-list')
+        )
+
+    def get_http_result(self, payload):
+        # Return the payload as is, it's a list.
+        return payload
+
+
 class AutocompleteUrlConvertComplex(AgnocompleteUrlProxy):
     def get_search_url(self):
         return '{}{}'.format(
@@ -245,6 +273,8 @@ register(AutocompleteContextTag)
 register(AutocompleteUrlSimple)
 register(AutocompleteUrlConvert)
 register(AutocompleteUrlConvertComplex)
+register(AutocompleteUrlConvertSchema)
+register(AutocompleteUrlConvertSchemaList)
 register(AutocompleteUrlSimpleAuth)
 register(AutocompleteUrlHeadersAuth)
 register(AutocompleteUrlSimplePost)

--- a/demo/tests/__init__.py
+++ b/demo/tests/__init__.py
@@ -31,7 +31,7 @@ class LoaddataLiveTestCase(LoaddataMixin, LiveServerTestCase):
 class RegistryTestGeneric(LoaddataTestCase):
 
     def _test_registry_keys(self, keys):
-        self.assertEqual(len(keys), 18)
+        self.assertEqual(len(keys), 20)
         self.assertIn("AutocompleteColor", keys)
         self.assertIn("AutocompleteColorExtra", keys)
         self.assertIn("AutocompletePerson", keys)
@@ -53,6 +53,8 @@ class RegistryTestGeneric(LoaddataTestCase):
         self.assertIn("AutocompleteUrlSimple", keys)
         self.assertIn("AutocompleteUrlSimplePost", keys)
         self.assertIn("AutocompleteUrlConvert", keys)
+        self.assertIn("AutocompleteUrlConvertSchema", keys)
+        self.assertIn("AutocompleteUrlConvertSchemaList", keys)
         self.assertIn("AutocompleteUrlConvertComplex", keys)
         self.assertIn("AutocompleteUrlSimpleAuth", keys)
         self.assertIn("AutocompleteUrlHeadersAuth", keys)

--- a/demo/tests/test_url_proxy.py
+++ b/demo/tests/test_url_proxy.py
@@ -12,6 +12,8 @@ from requests.exceptions import HTTPError
 from ..autocomplete import (
     AutocompleteUrlSimple,
     AutocompleteUrlConvert,
+    AutocompleteUrlConvertSchema,
+    AutocompleteUrlConvertSchemaList,
     AutocompleteUrlConvertComplex,
     AutocompleteUrlSimpleAuth,
     AutocompleteUrlHeadersAuth,
@@ -94,9 +96,59 @@ class AutocompleteUrlConvertTest(LiveServerTestCase):
 @override_settings(
     HTTP_HOST='',
 )
+class AutocompleteUrlConvertSchemaTest(LiveServerTestCase):
+    """
+    The AutocompleteUrlConvertSchema URL returns a non-standard schema.
+    """
+    def test_search(self):
+        instance = AutocompleteUrlConvertSchema()
+        # "mock" Change URL by adding the host
+        search_url = instance.search_url
+        with mock.patch('demo.autocomplete.AutocompleteUrlConvertSchema'
+                        '.get_search_url') as mock_auto:
+            mock_auto.return_value = self.live_server_url + search_url
+            self.assertEqual(
+                list(instance.items(query='person')), RESULT_DICT
+            )
+            # Search for first person
+            self.assertEqual(
+                list(instance.items(query='first')), [
+                    {'value': '1', 'label': 'first person'},
+                ],
+            )
+
+
+@override_settings(
+    HTTP_HOST='',
+)
+class AutocompleteUrlConvertSchemaListTest(LiveServerTestCase):
+    """
+    The AutocompleteUrlConvertSchemaList URL returns a list.
+    """
+    def test_search(self):
+        instance = AutocompleteUrlConvertSchemaList()
+        # "mock" Change URL by adding the host
+        search_url = instance.search_url
+        with mock.patch('demo.autocomplete.AutocompleteUrlConvertSchemaList'
+                        '.get_search_url') as mock_auto:
+            mock_auto.return_value = self.live_server_url + search_url
+            self.assertEqual(
+                list(instance.items(query='person')), RESULT_DICT
+            )
+            # Search for first person
+            self.assertEqual(
+                list(instance.items(query='first')), [
+                    {'value': '1', 'label': 'first person'},
+                ],
+            )
+
+
+@override_settings(
+    HTTP_HOST='',
+)
 class AutocompleteUrlConvertComplexTest(LiveServerTestCase):
     """
-    The AutocompleteUrlConvertComplex returns a different JSON format.
+    The AutocompleteUrlConvertComplex returns a different item format.
     """
     def test_search(self):
         instance = AutocompleteUrlConvertComplex()

--- a/demo/tests/test_url_proxy_views.py
+++ b/demo/tests/test_url_proxy_views.py
@@ -8,6 +8,7 @@ from .. import DATABASE, GOODAUTHTOKEN
 
 class UrlProxyGenericTest(object):
     method = 'get'
+    data_key = 'data'
 
     @property
     def http_url(self):
@@ -34,8 +35,8 @@ class UrlProxyGenericTest(object):
         response = self.http_call('person', self.method)
         self.assertEqual(response.status_code, 200)
         result = json.loads(response.content.decode())
-        self.assertIn('data', result)
-        data = result['data']
+        self.assertIn(self.data_key, result)
+        data = result[self.data_key]
         # Result data is a list
         self.assertTrue(isinstance(data, list))
         # Result data is not empty
@@ -51,8 +52,8 @@ class UrlProxyGenericTest(object):
         response = self.http_call('first', self.method)
         self.assertEqual(response.status_code, 200)
         result = json.loads(response.content.decode())
-        self.assertIn('data', result)
-        data = result['data']
+        self.assertIn(self.data_key, result)
+        data = result[self.data_key]
         # Result data is a list
         self.assertTrue(isinstance(data, list))
         # Result data is not empty
@@ -63,8 +64,8 @@ class UrlProxyGenericTest(object):
         response = self.http_call('lorem ipsum', self.method)
         self.assertEqual(response.status_code, 200)
         result = json.loads(response.content.decode())
-        self.assertIn('data', result)
-        data = result['data']
+        self.assertIn(self.data_key, result)
+        data = result[self.data_key]
         # Result data is a list
         self.assertTrue(isinstance(data, list))
         # Result data is empty
@@ -95,12 +96,15 @@ class UrlProxyConvertComplexTest(UrlProxyGenericTest, TestCase):
 
 
 class UrlProxyItemTest(TestCase):
+
+    data_key = 'data'
+
     def test_item(self):
         response = self.client.get(reverse('url-proxy:item', args=[4]))
         self.assertEqual(response.status_code, 200)
         result = json.loads(response.content.decode())
-        self.assertIn('data', result)
-        data = result['data']
+        self.assertIn(self.data_key, result)
+        data = result[self.data_key]
         # Result data is a list
         self.assertTrue(isinstance(data, list))
         # Result data is not empty
@@ -173,3 +177,22 @@ class UrlProxySimplePostTest(UrlProxyGenericTest, TestCase):
         # GET requests are forbidden
         response = self.http_call('hello', 'get')
         self.assertEqual(response.status_code, 405)
+
+
+class UrlProxyConvertSchemaTest(UrlProxyGenericTest, TestCase):
+    http_url = reverse('url-proxy:convert-schema')
+    # Returning the standard items, but embedded in "result"
+    data_key = 'result'
+    value_key = 'value'
+    label_key = 'label'
+
+    def test_search_person(self):
+        # GET requests are forbidden
+        response = self.client.get(
+            self.http_url,
+            {'q': 'person'},
+        )
+        self.assertEqual(response.status_code, 200)
+        result = json.loads(response.content.decode())
+        # Not "data"
+        self.assertNotIn('data', result)

--- a/demo/tests/test_url_proxy_views.py
+++ b/demo/tests/test_url_proxy_views.py
@@ -187,7 +187,6 @@ class UrlProxyConvertSchemaTest(UrlProxyGenericTest, TestCase):
     label_key = 'label'
 
     def test_search_person(self):
-        # GET requests are forbidden
         response = self.client.get(
             self.http_url,
             {'q': 'person'},
@@ -196,3 +195,17 @@ class UrlProxyConvertSchemaTest(UrlProxyGenericTest, TestCase):
         result = json.loads(response.content.decode())
         # Not "data"
         self.assertNotIn('data', result)
+
+
+class UrlProxyConvertSchemaListTest(TestCase):
+    http_url = reverse('url-proxy:convert-schema-list')
+    # Returning the standard items, but as a list
+
+    def test_search_person(self):
+        response = self.client.get(
+            self.http_url,
+            {'q': 'person'},
+        )
+        self.assertEqual(response.status_code, 200)
+        result = json.loads(response.content.decode())
+        self.assertTrue(isinstance(result, list))

--- a/demo/urls_proxy.py
+++ b/demo/urls_proxy.py
@@ -12,6 +12,8 @@ urlpatterns = [
     url(r'^convert/$', views_proxy.convert, name='convert'),
     url(r'^convert-complex/$',
         views_proxy.convert_complex, name='convert-complex'),
+    url(r'^convert-schema/$',
+        views_proxy.convert_schema, name='convert-schema'),
     url(r'^simple-auth/$', views_proxy.simple_auth, name='simple-auth'),
     url(r'^headers-auth/$', views_proxy.headers_auth, name='headers-auth'),
 ]

--- a/demo/urls_proxy.py
+++ b/demo/urls_proxy.py
@@ -14,6 +14,8 @@ urlpatterns = [
         views_proxy.convert_complex, name='convert-complex'),
     url(r'^convert-schema/$',
         views_proxy.convert_schema, name='convert-schema'),
+    url(r'^convert-schema-list/$',
+        views_proxy.convert_schema_list, name='convert-schema-list'),
     url(r'^simple-auth/$', views_proxy.simple_auth, name='simple-auth'),
     url(r'^headers-auth/$', views_proxy.headers_auth, name='headers-auth'),
 ]

--- a/demo/views_proxy.py
+++ b/demo/views_proxy.py
@@ -80,6 +80,21 @@ def convert_schema(request, *args, **kwargs):
 
 
 @require_GET
+def convert_schema_list(request, *args, **kwargs):
+    """
+    Return a list of items not embedded in a dict.
+    """
+    search_term = request.GET.get('q', None)
+    # Fetching result without converting item JSON payload.
+    result = _search(search_term, convert_data)
+    response = json.dumps(result.get('data', []))
+    logger.debug(
+        '3rd party schema conversion search w/ list: `%s`', search_term)
+    logger.debug('response: `%s`', response)
+    return HttpResponse(response)
+
+
+@require_GET
 def simple_auth(request, *args, **kwargs):
     # Check authentication
     auth_token = request.GET.get('auth_token', None)

--- a/demo/views_proxy.py
+++ b/demo/views_proxy.py
@@ -24,14 +24,14 @@ def convert_data_complex(item):
     }
 
 
-def _search(search_term, convert_func):
+def _search(search_term, convert_func, key='data'):
     data = []
     if search_term:
         data = filter(lambda x: search_term in x['name'], DATABASE)
     if data and convert_func:
         data = map(convert_func, data)
     data = list(data)
-    result = {'data': data}
+    result = {key: data}
     return result
 
 
@@ -64,6 +64,17 @@ def convert_complex(request, *args, **kwargs):
     result = _search(search_term, convert_data_complex)
     response = json.dumps(result)
     logger.debug('3rd party complex conversion search: `%s`', search_term)
+    logger.debug('response: `%s`', response)
+    return HttpResponse(response)
+
+
+@require_GET
+def convert_schema(request, *args, **kwargs):
+    search_term = request.GET.get('q', None)
+    # Fetching result without converting item JSON payload.
+    result = _search(search_term, convert_data, key='result')
+    response = json.dumps(result)
+    logger.debug('3rd party schema conversion search: `%s`', search_term)
     logger.debug('response: `%s`', response)
     return HttpResponse(response)
 

--- a/docs/url-proxy.rst
+++ b/docs/url-proxy.rst
@@ -32,10 +32,26 @@ then, you won't have to do anything else: this service will return data directly
 What if it doesn't return the standard agnocomplete JSON?
 ---------------------------------------------------------
 
-You'll have to convert this data into a format known by the agnocomplete widgets. Hopefully, we're providing simple parameters to make an easy conversion.
+By default, ``django-agnocomplete`` assumes that the returned data looks like this:
 
-What's configurable?
-++++++++++++++++++++
+.. code-block:: json
+
+    {
+        "data": [
+            {"value": "value", "label": "label"},
+            {"value": "value2", "label": "label2"},
+            {"value": "etc, etc", "label": "etc, etc..."}
+        ]
+    }
+
+Of course, this very simple structure is a bit biased and we're sure it's not even a standard.
+
+As a consequence, you'll probablay have to convert this data into a format known by the agnocomplete widgets. Hopefully, we're providing simple parameters and methods to make an easy conversion.
+
+Configurable parameters
++++++++++++++++++++++++
+
+If your target API follows the dataset structure, you have two params to adjust to your return schema.
 
 * ``value_key``: the name of the key in the item dictionary to be used for ``value``,
 * ``label_key``: the name of the key in the item dictionary to be used for ``label``,
@@ -60,10 +76,8 @@ will be converted like this before being returned by the search:
 
     {"value": 19911, "label": "Inigo Montoya"}
 
-For more complicated cases
-++++++++++++++++++++++++++
-
-If the returned JSON is in now way similar to what you were expecting, you have several options:
+If you need to merge fields
++++++++++++++++++++++++++++
 
 **If the JSON is a list or an iterable**, you can override the `Agnocomplete` class :meth:`item()` method, like this:
 
@@ -89,6 +103,24 @@ or, if things are going more complicated:
                 value=current_item[current_item['meta']['value_field']],
                 label='{} {}'.format(current_item['label1'], current_item['label2']),
             )
+
+If the result doesn't follow standard schema
+++++++++++++++++++++++++++++++++++++++++++++
+
+The :meth:`get_http_result` is ready to be overridden.
+
+.. important::
+
+    this overridden/overwritten method **must** return an iterable (list, set, tuple...)
+
+Simple example:
+
+.. code-block:: python
+
+    class AutocompleteUrlSchema(AgnocompleteUrlProxy):
+        def get_http_result(self, payload):
+            return payload.get('result', [])
+
 
 Passing extra arguments to the API call
 ---------------------------------------

--- a/docs/url-proxy.rst
+++ b/docs/url-proxy.rst
@@ -107,7 +107,27 @@ or, if things are going more complicated:
 If the result doesn't follow standard schema
 ++++++++++++++++++++++++++++++++++++++++++++
 
-The :meth:`get_http_result` is ready to be overridden.
+The simplest case is this one:
+
+.. code-block:: json
+
+    {
+        "resultset": [
+            {"value": "value", "label": "label"},
+            {"value": "value2", "label": "label2"},
+            {"value": "etc, etc", "label": "etc, etc..."}
+        ]
+    }
+
+Your dataset is embedded in a dictionary, but the key to this dataset is not ``data`` but *something else*. You'll only have to give a different value to the class property ``data_key``.
+
+
+.. code-block:: python
+
+    class AutocompleteUrlConvert(AgnocompleteUrlProxy):
+        data_key = 'resultset'
+
+If your result payload is more complicated and you need to loop over it or transform it, you can still overwrite/override the method :meth:`get_http_result`.
 
 .. important::
 
@@ -119,7 +139,8 @@ Simple example:
 
     class AutocompleteUrlSchema(AgnocompleteUrlProxy):
         def get_http_result(self, payload):
-            return payload.get('result', [])
+            return payload.get('meta', {}).get('dataset', {})
+
 
 
 Passing extra arguments to the API call


### PR DESCRIPTION
some API don't return datasets using a `{"data": [.....]}` format
