### PR TITLE
Global Error Handling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ master (unreleased)
 - Added support for extra arguments passed to the search URL, passed on the Agnocomplete class (#52).
 - Added the ``AgnocompleteUrlProxy`` class, handling autocomplete using a third-party HTTP API (#55, #62, #63).
 - Removed Django 1.10 deprecation warnings (#59).
+- Global Error Handling (#60).
 
 0.5.0 (2016-07-01)
 ==================

--- a/agnocomplete/core.py
+++ b/agnocomplete/core.py
@@ -539,7 +539,7 @@ class AgnocompleteUrlProxy(with_metaclass(ABCMeta, AgnocompleteBase)):
         )
         # Error handling
         if response.status_code != 200:
-            logger.warning('Invalid Authentication for `%s`', response.url)
+            logger.warning('Invalid Request for `%s`', response.url)
             # Raising a "requests" exception
             response.raise_for_status()
         return response.json()
@@ -581,10 +581,12 @@ class AgnocompleteUrlProxy(with_metaclass(ABCMeta, AgnocompleteBase)):
             return []
         # Call to search URL
         http_result = self.http_call(**self.get_http_call_kwargs(query))
-        # TODO: Eventual error handling
+        # In case of error, on the API side, the error is raised and handled
+        # in the view.
         http_result = self.get_http_result(http_result)
         result = []
         for item in http_result:
+            # Eventual result reshaping.
             result.append(self.item(item))
         return result
 

--- a/demo/autocomplete.py
+++ b/demo/autocomplete.py
@@ -228,6 +228,12 @@ class AutocompleteUrlSimplePost(AutocompleteUrlMixin):
     url_search_string = 'url-proxy:simple-post'
 
 
+class AutocompleteUrlErrors(AutocompleteUrlMixin):
+    url_search_string = 'url-proxy:errors'
+    query_size = 2
+    query_size_min = 2
+
+
 # Registration
 register(AutocompleteColor)
 register(AutocompleteColorExtra)
@@ -250,3 +256,4 @@ register(AutocompleteUrlConvertSchemaList)
 register(AutocompleteUrlSimpleAuth)
 register(AutocompleteUrlHeadersAuth)
 register(AutocompleteUrlSimplePost)
+register(AutocompleteUrlErrors)

--- a/demo/forms.py
+++ b/demo/forms.py
@@ -138,3 +138,17 @@ class UrlProxyAuthForm(UrlProxyFormMixin, forms.Form):
     person_headers_auth = fields.AgnocompleteField(
         'AutocompleteUrlHeadersAuth',
         help_text='Headers-based authentication')
+
+
+class UrlProxyErrors(forms.Form):
+    help_text = """
+This form fields will call a URL that will **always** send a HTTP error.
+If you want a specific HTTP status to be returned, type it in the search bar.
+
+e.g.: "hello 404" will return a 404 NOT FOUND.
+
+Use your favorite Browser dev tool to inspect it.
+"""
+    person = fields.AgnocompleteField(
+        'AutocompleteUrlErrors',
+        help_text='will never find anybody')

--- a/demo/templates/includes/nav.html
+++ b/demo/templates/includes/nav.html
@@ -23,4 +23,5 @@
     <li><a href="{% url 'url-proxy-simple' %}">Simple URL, returned data without transformation</a></li>
     <li><a href="{% url 'url-proxy-convert' %}">Simple URL, returned data with more or less data converted</a></li>
     <li><a href="{% url 'url-proxy-auth' %}">Authenticated URLs</a></li>
+    <li><a href="{% url 'url-proxy-errors' %}">Error Handling</a></li>
 </ul>

--- a/demo/tests/__init__.py
+++ b/demo/tests/__init__.py
@@ -1,3 +1,6 @@
+# -*- coding: utf8 -*-
+import json
+
 from django.test import TestCase, LiveServerTestCase
 from django.core.management import call_command
 
@@ -68,3 +71,10 @@ class MockRequestUser(object):
 
     def is_authenticated(self):
         return self._is_authenticated
+
+
+def get_json(response, key='data'):
+    data = json.loads(response.content.decode())
+    if key:
+        return data.get(key, None)
+    return data

--- a/demo/tests/__init__.py
+++ b/demo/tests/__init__.py
@@ -34,7 +34,7 @@ class LoaddataLiveTestCase(LoaddataMixin, LiveServerTestCase):
 class RegistryTestGeneric(LoaddataTestCase):
 
     def _test_registry_keys(self, keys):
-        self.assertEqual(len(keys), 20)
+        self.assertEqual(len(keys), 21)
         self.assertIn("AutocompleteColor", keys)
         self.assertIn("AutocompleteColorExtra", keys)
         self.assertIn("AutocompletePerson", keys)
@@ -61,6 +61,7 @@ class RegistryTestGeneric(LoaddataTestCase):
         self.assertIn("AutocompleteUrlConvertComplex", keys)
         self.assertIn("AutocompleteUrlSimpleAuth", keys)
         self.assertIn("AutocompleteUrlHeadersAuth", keys)
+        self.assertIn("AutocompleteUrlErrors", keys)
 
 
 class MockRequestUser(object):

--- a/demo/tests/test_demo_views.py
+++ b/demo/tests/test_demo_views.py
@@ -4,7 +4,6 @@ from django.core.urlresolvers import reverse
 from django.test import override_settings
 
 import mock
-from requests.exceptions import HTTPError
 
 from agnocomplete import get_namespace
 from agnocomplete.views import AgnocompleteJSONView
@@ -632,49 +631,3 @@ class UrlProxyAuthTest(LoaddataLiveTestCase):
             result = json.loads(response.content.decode())
             data = result.get('data')
             self.assertEqual(len(data), 7)
-
-    def test_search_query_wrong_auth(self):
-        # URL construct
-        instance = AutocompleteUrlSimpleAuth()
-        search_url = instance.search_url
-        klass = 'demo.autocomplete.AutocompleteUrlSimpleAuth'
-        with mock.patch(klass + '.get_search_url') as mock_auto:
-            mock_auto.return_value = self.live_server_url + search_url
-            # Search using the URL proxy view
-            search_url = get_namespace() + ':agnocomplete'
-
-            with mock.patch(klass + '.get_http_call_kwargs') as mock_headers:
-                mock_headers.return_value = {
-                    'auth_token': 'BADAUTHTOKEN',
-                    'q': 'person',
-                }
-                # TODO: We'll probably have to handle a custom error process
-                # ATM we're passing the HTTPError back to the front-end.
-                with self.assertRaises(HTTPError):
-                    self.client.get(
-                        reverse(
-                            search_url, args=['AutocompleteUrlSimpleAuth']),
-                        data={'q': "person"}
-                    )
-
-    def test_search_headers_wrong_auth(self):
-        # URL construct
-        instance = AutocompleteUrlHeadersAuth()
-        search_url = instance.search_url
-        klass = 'demo.autocomplete.AutocompleteUrlHeadersAuth'
-        with mock.patch(klass + '.get_search_url') as mock_auto:
-            mock_auto.return_value = self.live_server_url + search_url
-            # Search using the URL proxy view
-            search_url = get_namespace() + ':agnocomplete'
-            with mock.patch(klass + '.get_http_headers') as mock_headers:
-                mock_headers.return_value = {
-                    'NOTHING': 'HERE'
-                }
-                # TODO: We'll probably have to handle a custom error process
-                # ATM we're passing the HTTPError back to the front-end.
-                with self.assertRaises(HTTPError):
-                    self.client.get(
-                        reverse(
-                            search_url, args=['AutocompleteUrlHeadersAuth']),
-                        data={'q': "person"}
-                    )

--- a/demo/tests/test_errors.py
+++ b/demo/tests/test_errors.py
@@ -1,0 +1,153 @@
+from django.test import TestCase
+from django.core.urlresolvers import reverse
+from django.test import override_settings
+from django.core.exceptions import SuspiciousOperation
+
+import mock
+from requests.exceptions import Timeout
+
+from agnocomplete import get_namespace
+
+from . import get_json
+from . import LoaddataLiveTestCase
+from ..autocomplete import (
+    # Classic search
+    AutocompletePerson,
+    # URL Proxies
+    AutocompleteUrlSimpleAuth,
+    AutocompleteUrlHeadersAuth,
+)
+
+
+def raise_standard_exception(*args, **kwargs):
+    raise Exception("Nothing exceptional")
+
+
+def raise_suspiciousoperation(*args, **kwargs):
+    raise SuspiciousOperation("You are not allowed to do this")
+
+
+def raise_timeout(*args, **kwargs):
+    raise Timeout("Timeout")
+
+
+class ErrorHandlingTest(object):
+    expected_status = 500
+
+    @property
+    def klass(self):
+        raise NotImplementedError("You need a `klass` property")
+
+    @property
+    def mock_function(self):
+        raise NotImplementedError("You need a `mock_function` property")
+
+    @property
+    def klass_path(self):
+        return '{}.{}'.format(self.klass.__module__, self.klass.__name__)
+
+    @property
+    def mock_path(self):
+        paths = [self.klass_path, 'items']
+        return ".".join(paths)
+
+    @property
+    def url(self):
+        ac_url_name = get_namespace() + ':agnocomplete'
+        return reverse(ac_url_name, args=[self.klass.__name__])
+
+    def test_errors(self):
+        with mock.patch(self.mock_path, self.mock_function):
+            response = self.client.get(
+                self.url,
+                data={"q": "nothing important"})
+            self.assertEqual(response.status_code, self.expected_status)
+            data = get_json(response, 'errors')
+            self.assertEqual(len(data), 1)
+
+
+class ErrorHandlingAutocompletePersonTest(ErrorHandlingTest, TestCase):
+    klass = AutocompletePerson
+    mock_function = raise_standard_exception
+
+
+class ErrorHandlingSuspiciousOperationTest(ErrorHandlingTest, TestCase):
+    klass = AutocompletePerson
+    mock_function = raise_suspiciousoperation
+    expected_status = 400
+
+
+@override_settings(HTTP_HOST='')
+class ErrorHandlingURLProxySimpleAuthTest(
+        ErrorHandlingTest, LoaddataLiveTestCase):
+    klass = AutocompleteUrlSimpleAuth
+    mock_function = raise_standard_exception
+
+    def test_search_query_wrong_auth(self):
+        # URL construct
+        instance = self.klass()
+        search_url = instance.search_url
+        klass = self.klass_path
+        with mock.patch(klass + '.get_search_url') as mock_auto:
+            mock_auto.return_value = self.live_server_url + search_url
+            # Search using the URL proxy view
+            search_url = get_namespace() + ':agnocomplete'
+
+            with mock.patch(klass + '.get_http_call_kwargs') as mock_headers:
+                mock_headers.return_value = {
+                    'auth_token': 'BADAUTHTOKEN',
+                    'q': 'person',
+                }
+                response = self.client.get(
+                    reverse(
+                        search_url, args=[self.klass.__name__]),
+                    data={'q': "person"}
+                )
+                self.assertEqual(response.status_code, 403)
+
+
+@override_settings(HTTP_HOST='')
+class ErrorHandlingURLProxyHeadersAuthTest(
+        ErrorHandlingTest, LoaddataLiveTestCase):
+    klass = AutocompleteUrlHeadersAuth
+    mock_function = raise_standard_exception
+
+    def test_search_headers_wrong_auth(self):
+        # URL construct
+        instance = self.klass()
+        search_url = instance.search_url
+        klass = self.klass_path
+        with mock.patch(klass + '.get_search_url') as mock_auto:
+            mock_auto.return_value = self.live_server_url + search_url
+            # Search using the URL proxy view
+            search_url = get_namespace() + ':agnocomplete'
+            with mock.patch(klass + '.get_http_headers') as mock_headers:
+                mock_headers.return_value = {
+                    'NOTHING': 'HERE'
+                }
+                response = self.client.get(
+                    reverse(
+                        search_url, args=[self.klass.__name__]),
+                    data={'q': "person"}
+                )
+                self.assertEqual(response.status_code, 403)
+
+
+@override_settings(HTTP_HOST='')
+class ErrorHandlingURLProxyTimeoutTest(LoaddataLiveTestCase):
+    klass = AutocompleteUrlHeadersAuth
+
+    @property
+    def klass_path(self):
+        return '{}.{}'.format(self.klass.__module__, self.klass.__name__)
+
+    def test_timeout(self):
+        # Search using the URL proxy view
+        search_url = get_namespace() + ':agnocomplete'
+        with mock.patch('requests.get', raise_timeout):
+            response = self.client.get(
+                reverse(
+                    search_url, args=[self.klass.__name__]),
+                data={'q': "person"}
+            )
+            self.assertEqual(response.status_code, 408)

--- a/demo/tests/test_url_proxy_views.py
+++ b/demo/tests/test_url_proxy_views.py
@@ -209,3 +209,26 @@ class UrlProxyConvertSchemaListTest(TestCase):
         self.assertEqual(response.status_code, 200)
         result = json.loads(response.content.decode())
         self.assertTrue(isinstance(result, list))
+
+
+class UrlProxyErrorsTest(TestCase):
+
+    def test_400(self):
+        response = self.client.get(
+            reverse('url-proxy:errors'), {'q': '400'})
+        self.assertEqual(response.status_code, 400)
+
+    def test_403(self):
+        response = self.client.get(
+            reverse('url-proxy:errors'), {'q': '403'})
+        self.assertEqual(response.status_code, 403)
+
+    def test_404(self):
+        response = self.client.get(
+            reverse('url-proxy:errors'), {'q': '404'})
+        self.assertEqual(response.status_code, 404)
+
+    def test_500(self):
+        response = self.client.get(
+            reverse('url-proxy:errors'), {'q': 'whatever'})
+        self.assertEqual(response.status_code, 500)

--- a/demo/tests/test_views.py
+++ b/demo/tests/test_views.py
@@ -1,6 +1,4 @@
 # -*- coding: utf8 -*-
-import json
-
 from django.core.urlresolvers import reverse
 from django.utils.encoding import force_text as text
 from django.contrib.auth.models import User
@@ -8,14 +6,7 @@ from django.contrib.auth.models import User
 from agnocomplete import get_namespace
 
 from ..models import Person
-from . import RegistryTestGeneric
-
-
-def get_json(response, key='data'):
-    data = json.loads(response.content.decode())
-    if key:
-        return data.get(key, None)
-    return data
+from . import RegistryTestGeneric, get_json
 
 
 class NamespaceGeneric(object):

--- a/demo/urls.py
+++ b/demo/urls.py
@@ -57,6 +57,8 @@ urlpatterns = [
         name='url-proxy-convert'),
     url(r'^url-proxy-auth/$', views.url_proxy_auth,
         name='url-proxy-auth'),
+    url(r'^url-proxy-errors/$', views.url_proxy_errors,
+        name='url-proxy-errors'),
 
     # Mock Third Party URLs
     url(r'^3rdparty/', include('demo.urls_proxy', namespace='url-proxy')),

--- a/demo/urls_proxy.py
+++ b/demo/urls_proxy.py
@@ -18,4 +18,5 @@ urlpatterns = [
         views_proxy.convert_schema_list, name='convert-schema-list'),
     url(r'^simple-auth/$', views_proxy.simple_auth, name='simple-auth'),
     url(r'^headers-auth/$', views_proxy.headers_auth, name='headers-auth'),
+    url(r'^errors/$', views_proxy.errors, name='errors'),
 ]

--- a/demo/views.py
+++ b/demo/views.py
@@ -18,7 +18,7 @@ from .forms import (
     PersonTagModelFormWithCreate,
     PersonContextTagModelForm,
     UrlProxyForm, UrlProxyConvertForm,
-    UrlProxyAuthForm,
+    UrlProxyAuthForm, UrlProxyErrors,
 )
 from .autocomplete import HiddenAutocomplete
 from .models import PersonTag
@@ -191,6 +191,12 @@ class UrlProxyAuthView(AutoView):
     template_name = "selectize.html"
 
 
+class UrlProxyErrorsView(AutoView):
+    form_class = UrlProxyErrors
+    title = 'URLs that will always return an error'
+    template_name = "selectize.html"
+
+
 index = IndexView.as_view()
 filled_form = FilledFormView.as_view()
 search_context = SearchContextFormView.as_view()
@@ -214,3 +220,4 @@ selectize_context_tag = PersonContextTagView.as_view()
 url_proxy_simple = UrlProxySimpleView.as_view()
 url_proxy_convert = UrlProxyConvertView.as_view()
 url_proxy_auth = UrlProxyAuthView.as_view()
+url_proxy_errors = UrlProxyErrorsView.as_view()

--- a/demo/views_proxy.py
+++ b/demo/views_proxy.py
@@ -2,7 +2,15 @@ import json
 import logging
 
 from django.core.exceptions import PermissionDenied
-from django.http import HttpResponse, Http404
+from django.http import (
+    HttpResponse,
+    Http404,
+    HttpResponseNotFound,
+    HttpResponseBadRequest,
+    HttpResponseForbidden,
+    HttpResponseNotAllowed,
+    HttpResponseServerError,
+)
 from django.utils.encoding import force_text as text
 from django.views.decorators.http import require_GET, require_POST
 
@@ -132,6 +140,25 @@ def simple_post(request, *args, **kwargs):
     logger.debug('3rd party POST search: `%s`', search_term)
     logger.debug('response: `%s`', response)
     return HttpResponse(response)
+
+
+@require_GET
+def errors(request, *args, **kwargs):
+    """
+    A dummy view that will throw errors.
+
+    It'll throw any HTTP error that is contained in the search query.
+    """
+    search_term = request.GET.get('q', None)
+    if '400' in search_term:
+        return HttpResponseBadRequest()
+    elif '403' in search_term:
+        return HttpResponseForbidden()
+    elif '404' in search_term:
+        return HttpResponseNotFound()
+    elif '405' in search_term:
+        return HttpResponseNotAllowed()
+    return HttpResponseServerError()
 
 
 @require_GET

--- a/docs/error-handling.rst
+++ b/docs/error-handling.rst
@@ -1,0 +1,23 @@
+==============
+Error Handling
+==============
+
+We're handling errors on many levels. What the front-end integrators need to know is that, if an error occurs at some point (Database, HTTP request, etc), the corresponding payload is sent back to the user:
+
+.. code-block:: json
+
+    {
+        "errors": [
+            {
+                "title": "Database Error",
+                "detail": "An error has occurred. Please contact your administrator"
+            }
+        ]
+    }
+
+This error payload format is inspired by `JSON API <http://jsonapi.org/format/#errors>`_
+
+
+.. important::
+
+    Along with this payload, the response status code may be a 4xx or a 5xx depending on the error raised.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,6 +34,7 @@ So far, we've got it implemented using:
    url-proxy
    custom-views
    fields-widgets
+   error-handling
    demo-site
    admin-site
 


### PR DESCRIPTION
- [x] define the way errors are handled in the core module, use the right format that could be processed by the front-end the easiest way (send a message using a simple structure + throwing the HTTP status header looks like the best candidate)
- [x] tests for all the core variants,
- [x] amend documentation accordingly,
- [x] Demo views
