### PR TITLE
Indifferently use str and unicode strings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ master (unreleased)
 - Added the ``AgnocompleteUrlProxy`` class, handling autocomplete using a third-party HTTP API (#55, #62, #63).
 - Removed Django 1.10 deprecation warnings (#59).
 - Global Error Handling (#60).
+- Allowing Autocomplete class argument in AgnocompleteField to be either string (``str``) or unicode variables (#66).
 
 0.5.0 (2016-07-01)
 ==================

--- a/agnocomplete/fields.py
+++ b/agnocomplete/fields.py
@@ -4,6 +4,8 @@ Agnocomplete specific form fields.
 """
 from django import forms
 
+import six
+
 from .core import AgnocompleteBase
 from .constants import AGNOCOMPLETE_USER_ATTRIBUTE
 from .widgets import AgnocompleteSelect, AgnocompleteMultiSelect
@@ -55,7 +57,7 @@ class AgnocompleteMixin(object):
 
         """
         # If string, use register to fetch the class
-        if isinstance(klass_or_instance, str):
+        if isinstance(klass_or_instance, six.string_types):
             registry = get_agnocomplete_registry()
             if klass_or_instance not in registry:
                 raise UnregisteredAgnocompleteException(

--- a/demo/tests/test_fields.py
+++ b/demo/tests/test_fields.py
@@ -1,6 +1,8 @@
 from django.test import TestCase
 from django.core.urlresolvers import reverse
 
+import six
+
 from agnocomplete.fields import (
     AgnocompleteField,
     AgnocompleteMultipleField,
@@ -37,6 +39,11 @@ class AgnocompleteInstanceTest(TestCase):
     def test_unkown_string(self):
         with self.assertRaises(UnregisteredAgnocompleteException):
             AgnocompleteField('MEUUUUUUH')
+
+    def test_unicode(self):
+        field = AgnocompleteField(six.u('AutocompleteColor'))
+        self.assertTrue(field.agnocomplete)
+        self.assertTrue(isinstance(field.agnocomplete, AutocompleteColor))
 
     def test_instance_url(self):
         field = AgnocompleteField(AutocompleteColor())


### PR DESCRIPTION
[this line](https://github.com/novafloss/django-agnocomplete/blob/0.5.0/agnocomplete/fields.py#L58) doesn't properly work if this is not a string, but a unicode object passed to the constructor.
