### PR TITLE
Bugfix: allow to use extra query arguments for URL proxy classes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ master (unreleased)
 - Dropped support for Django 1.6 / 1.7 (#54),
 - Added support for Django 1.9. Please note that the combination Python 3.3 and Django 1.9 is incompatible - `see Django 1.9 release notes <https://docs.djangoproject.com/en/1.10/releases/1.9/>`_ (#56).
 - Added support for extra arguments passed to the search URL, passed on the Agnocomplete class (#52).
-- Added the ``AgnocompleteUrlProxy`` class, handling autocomplete using a third-party HTTP API (#55, #62, #63).
+- Added the ``AgnocompleteUrlProxy`` class, handling autocomplete using a third-party HTTP API (#55, #62, #63, #67).
 - Removed Django 1.10 deprecation warnings (#59).
 - Global Error Handling (#60).
 - Allowing Autocomplete class argument in AgnocompleteField to be either string (``str``) or unicode variables (#66).

--- a/agnocomplete/core.py
+++ b/agnocomplete/core.py
@@ -567,7 +567,7 @@ class AgnocompleteUrlProxy(with_metaclass(ABCMeta, AgnocompleteBase)):
         """
         return http_result.get(self.data_key, [])
 
-    def get_http_call_kwargs(self, query):
+    def get_http_call_kwargs(self, query, **kwargs):
         """
         Return the HTTP query arguments.
 
@@ -580,7 +580,9 @@ class AgnocompleteUrlProxy(with_metaclass(ABCMeta, AgnocompleteBase)):
         if not self.is_valid_query(query):
             return []
         # Call to search URL
-        http_result = self.http_call(**self.get_http_call_kwargs(query))
+        http_result = self.http_call(
+            **self.get_http_call_kwargs(query, **kwargs)
+        )
         # In case of error, on the API side, the error is raised and handled
         # in the view.
         http_result = self.get_http_result(http_result)

--- a/agnocomplete/core.py
+++ b/agnocomplete/core.py
@@ -576,7 +576,7 @@ class AgnocompleteUrlProxy(with_metaclass(ABCMeta, AgnocompleteBase)):
         """
         return {'q': query}
 
-    def items(self, query=None):
+    def items(self, query=None, **kwargs):
         if not self.is_valid_query(query):
             return []
         # Call to search URL

--- a/demo/autocomplete.py
+++ b/demo/autocomplete.py
@@ -239,9 +239,12 @@ class AutocompleteUrlErrors(AutocompleteUrlMixin):
 
 
 class AutocompleteUrlSimpleWithExtra(AutocompleteUrlSimple):
+    query_size = 2
+    query_size_min = 2
+
     def items(self, query=None, **kwargs):
         logger.debug("I am exploiting the kwargs [%s]", kwargs)
-        if 'special' in kwargs and kwargs['special'] == 'moo':
+        if 'extra_argument' in kwargs and kwargs['extra_argument'] == 'moo':
             return [{'value': 'moo', 'label': 'moo'}]
         return super(AutocompleteUrlSimple, self).items(query, **kwargs)
 

--- a/demo/autocomplete.py
+++ b/demo/autocomplete.py
@@ -1,6 +1,7 @@
 """
 Autocomplete classes
 """
+import logging
 from django.core.urlresolvers import reverse_lazy
 from django.utils.encoding import force_text as text
 from django.conf import settings
@@ -14,6 +15,9 @@ from agnocomplete.core import (
 from .models import Person, Tag, ContextTag
 from .common import COLORS
 from . import GOODAUTHTOKEN
+
+
+logger = logging.getLogger(__name__)
 
 
 class AutocompleteColor(AgnocompleteChoices):
@@ -234,6 +238,14 @@ class AutocompleteUrlErrors(AutocompleteUrlMixin):
     query_size_min = 2
 
 
+class AutocompleteUrlSimpleWithExtra(AutocompleteUrlSimple):
+    def items(self, query=None, **kwargs):
+        logger.debug("I am exploiting the kwargs [%s]", kwargs)
+        if 'special' in kwargs and kwargs['special'] == 'moo':
+            return [{'value': 'moo', 'label': 'moo'}]
+        return super(AutocompleteUrlSimple, self).items(query, **kwargs)
+
+
 # Registration
 register(AutocompleteColor)
 register(AutocompleteColorExtra)
@@ -257,3 +269,4 @@ register(AutocompleteUrlSimpleAuth)
 register(AutocompleteUrlHeadersAuth)
 register(AutocompleteUrlSimplePost)
 register(AutocompleteUrlErrors)
+register(AutocompleteUrlSimpleWithExtra)

--- a/demo/forms.py
+++ b/demo/forms.py
@@ -31,9 +31,9 @@ class SearchForm(forms.Form):
 
 
 class SearchFormExtra(forms.Form):
+    extra_argument = forms.CharField(required=False)
     search_color = fields.AgnocompleteField(AutocompleteColorExtra)
     search_person = fields.AgnocompleteModelField(AutocompletePersonExtra)
-    extra_argument = forms.CharField(required=False)
 
 
 class SearchFormTextInput(forms.Form):
@@ -157,15 +157,14 @@ Use your favorite Browser dev tool to inspect it.
 class UrlProxyWithExtraForm(forms.Form):
     help_text = UrlProxyFormMixin.help_text + """
 
-Please note that we're adding an extra argument to the search: `special`.
+Note: that we're adding an extra argument to the search: `extra_argument`.
 """
-
+    extra_argument = forms.CharField(required=False)
     person_simple = fields.AgnocompleteField(
         'AutocompleteUrlSimple',
         help_text='Simple search using GET',
     )
-
     person_simple_extra = fields.AgnocompleteField(
         'AutocompleteUrlSimpleWithExtra',
-        help_text='Simple search using GET, exploiting the "special" argument',
+        help_text='Simple search using GET, processing the "extra_argument"',
     )

--- a/demo/forms.py
+++ b/demo/forms.py
@@ -152,3 +152,20 @@ Use your favorite Browser dev tool to inspect it.
     person = fields.AgnocompleteField(
         'AutocompleteUrlErrors',
         help_text='will never find anybody')
+
+
+class UrlProxyWithExtraForm(forms.Form):
+    help_text = UrlProxyFormMixin.help_text + """
+
+Please note that we're adding an extra argument to the search: `special`.
+"""
+
+    person_simple = fields.AgnocompleteField(
+        'AutocompleteUrlSimple',
+        help_text='Simple search using GET',
+    )
+
+    person_simple_extra = fields.AgnocompleteField(
+        'AutocompleteUrlSimpleWithExtra',
+        help_text='Simple search using GET, exploiting the "special" argument',
+    )

--- a/demo/templates/includes/nav.html
+++ b/demo/templates/includes/nav.html
@@ -23,5 +23,6 @@
     <li><a href="{% url 'url-proxy-simple' %}">Simple URL, returned data without transformation</a></li>
     <li><a href="{% url 'url-proxy-convert' %}">Simple URL, returned data with more or less data converted</a></li>
     <li><a href="{% url 'url-proxy-auth' %}">Authenticated URLs</a></li>
+    <li><a href="{% url 'url-proxy-with-extra' %}">Views with extra data</a></li>
     <li><a href="{% url 'url-proxy-errors' %}">Error Handling</a></li>
 </ul>

--- a/demo/tests/__init__.py
+++ b/demo/tests/__init__.py
@@ -34,7 +34,7 @@ class LoaddataLiveTestCase(LoaddataMixin, LiveServerTestCase):
 class RegistryTestGeneric(LoaddataTestCase):
 
     def _test_registry_keys(self, keys):
-        self.assertEqual(len(keys), 21)
+        self.assertEqual(len(keys), 22)
         self.assertIn("AutocompleteColor", keys)
         self.assertIn("AutocompleteColorExtra", keys)
         self.assertIn("AutocompletePerson", keys)
@@ -62,6 +62,7 @@ class RegistryTestGeneric(LoaddataTestCase):
         self.assertIn("AutocompleteUrlSimpleAuth", keys)
         self.assertIn("AutocompleteUrlHeadersAuth", keys)
         self.assertIn("AutocompleteUrlErrors", keys)
+        self.assertIn("AutocompleteUrlSimpleWithExtra", keys)
 
 
 class MockRequestUser(object):

--- a/demo/tests/test_demo_views.py
+++ b/demo/tests/test_demo_views.py
@@ -237,6 +237,10 @@ class JSDemoViews(TestCase):
         response = self.client.get(reverse('url-proxy-auth'))
         self.assertEqual(response.status_code, 200)
 
+    def test_url_proxy_with_extra(self):
+        response = self.client.get(reverse('url-proxy-with-extra'))
+        self.assertEqual(response.status_code, 200)
+
 
 class FormValidationViewTest(LoaddataTestCase):
 

--- a/demo/tests/test_url_proxy.py
+++ b/demo/tests/test_url_proxy.py
@@ -286,7 +286,7 @@ class AutocompleteUrlWithExtraTest(LiveServerTestCase):
         instance = AutocompleteUrlSimpleWithExtra()
         # "moo" is an easter egg value here
         self.assertEqual(
-            list(instance.items(query='person', special='moo')),
+            list(instance.items(query='person', extra_argument='moo')),
             [
                 {'value': 'moo', 'label': 'moo'}
             ]

--- a/demo/urls.py
+++ b/demo/urls.py
@@ -59,6 +59,8 @@ urlpatterns = [
         name='url-proxy-auth'),
     url(r'^url-proxy-errors/$', views.url_proxy_errors,
         name='url-proxy-errors'),
+    url(r'^url-proxy-with-extra/$', views.url_proxy_with_extra,
+        name='url-proxy-with-extra'),
 
     # Mock Third Party URLs
     url(r'^3rdparty/', include('demo.urls_proxy', namespace='url-proxy')),

--- a/demo/views.py
+++ b/demo/views.py
@@ -19,6 +19,7 @@ from .forms import (
     PersonContextTagModelForm,
     UrlProxyForm, UrlProxyConvertForm,
     UrlProxyAuthForm, UrlProxyErrors,
+    UrlProxyWithExtraForm,
 )
 from .autocomplete import HiddenAutocomplete
 from .models import PersonTag
@@ -197,6 +198,12 @@ class UrlProxyErrorsView(AutoView):
     template_name = "selectize.html"
 
 
+class UrlProxyWithExtraView(AutoView):
+    form_class = UrlProxyWithExtraForm
+    title = 'Authenticated URLs, returned normal data'
+    template_name = "selectize.html"
+
+
 index = IndexView.as_view()
 filled_form = FilledFormView.as_view()
 search_context = SearchContextFormView.as_view()
@@ -221,3 +228,4 @@ url_proxy_simple = UrlProxySimpleView.as_view()
 url_proxy_convert = UrlProxyConvertView.as_view()
 url_proxy_auth = UrlProxyAuthView.as_view()
 url_proxy_errors = UrlProxyErrorsView.as_view()
+url_proxy_with_extra = UrlProxyWithExtraView.as_view()

--- a/demo/views.py
+++ b/demo/views.py
@@ -198,10 +198,9 @@ class UrlProxyErrorsView(AutoView):
     template_name = "selectize.html"
 
 
-class UrlProxyWithExtraView(AutoView):
+class UrlProxyWithExtraView(SelectizeExtraView):
     form_class = UrlProxyWithExtraForm
-    title = 'Authenticated URLs, returned normal data'
-    template_name = "selectize.html"
+    title = 'Using extra data and eventually processing it'
 
 
 index = IndexView.as_view()

--- a/docs/url-proxy.rst
+++ b/docs/url-proxy.rst
@@ -155,7 +155,7 @@ The :meth:`get_http_call_kwargs()` method is completely overridable like this:
     class AutocompleteUrlExtraArgs(AgnocompleteProxy):
         search_url = 'http://api.example.com/search'
 
-        def get_http_call_kwargs(self, query):
+        def get_http_call_kwargs(self, query, **kwargs):
             query_args = super(
                 AutocompleteUrlExtraArgs, self).get_http_call_kwargs(query)
             query_args['auth_token'] = 'GOODAUTHTOKEN'
@@ -167,11 +167,16 @@ The :meth:`get_http_call_kwargs()` method is completely overridable like this:
 
     .. code-block:: python
 
-        def get_http_call_kwargs(self, query):
+        def get_http_call_kwargs(self, query, **kwargs):
             return {
                 'search': query,
                 'auth_token': 'GOODAUTHTOKEN',
             }
+
+.. note::
+
+    Please note that the ``**kwargs`` argument passed into :meth:`get_http_call_kwargs` will be the same arguments passed to the :meth:`items` method. This way, you can manipulate the argument transmitted by the view to the Agnocomplete class and extract them, manipulate them using your context, etc.
+
 
 Adding headers to the HTTP call
 -------------------------------


### PR DESCRIPTION
- [x] `get_http_call_kwargs()` should accept kwargs
- [x] add the demo view + link in the navigation
