### PR TITLE
Doc build errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ master (unreleased)
 ===================
 
 - Added a ``make clean`` command to remove junk assets (#64).
+- Added a ``doclint`` job to check documentation build (#69).
 
 
 0.6.0 (2016-10-10)

--- a/docs/admin-site.rst
+++ b/docs/admin-site.rst
@@ -12,7 +12,7 @@ Let's imagine that you're building a new Django model, ``FavoriteColor``, that w
 
 .. literalinclude:: ../demo/models.py
    :language: python
-   :lines: 15-22
+   :lines: 32-38
 
 The Admin module
 ================

--- a/docs/doc_checker.py
+++ b/docs/doc_checker.py
@@ -1,0 +1,44 @@
+"""
+agnocomplete doc checker
+"""
+import os
+from copy import copy
+from os.path import abspath, dirname, join, splitext
+
+
+def grep(rootdir, searched):
+    "grep -l <searched>"
+    to_inspect = []
+    for root, dirs, files in os.walk(rootdir):
+        for _file in files:
+            if _file.endswith('.rst'):
+                to_inspect.append(join(root, _file))
+
+    to_check = ((_file, open(_file, 'r').read()) for _file in to_inspect)
+    to_check = filter(lambda item: searched in item[1], to_check)
+    to_check = map(lambda item: item[0], to_check)
+    return to_check
+
+
+def get_expected_html_files(rootdir, files):
+    html_files = map(lambda _file: splitext(_file), files)
+    html_files = map(lambda item: (item[0].replace(rootdir, '')), html_files)
+    html_files = map(lambda item: "{}{}.html".format('/_build/html', item), html_files)
+    return set(html_files)
+
+
+if __name__ == '__main__':
+    rootdir = abspath(dirname(__file__))
+    files = grep(rootdir, 'literalinclude')
+    expected_html_files = get_expected_html_files(rootdir, files)
+
+    # Manually fed:
+    html_files = ['admin-site.html', 'autocomplete-definition.html']
+    # CHECK!
+    files = copy(html_files)
+    files = map(lambda item: "{}/{}".format("/_build/html", item), files)
+    files = set(files)
+    diff = expected_html_files.symmetric_difference(files)
+    msg = "Have you checked every literalinclude?: {}".format(diff)
+    assert files == expected_html_files, msg
+    print("Reminder: Check your literalinclude in: {}".format(expected_html_files))

--- a/docs/fields-widgets.rst
+++ b/docs/fields-widgets.rst
@@ -70,7 +70,7 @@ Creation mode for Model Multiple Selectors
 
 The "create" mode with model-based fields is a bit different from the regular one. At the moment, ``agnocomplete`` is supporting a "one-field-model instance creation" only. And there are no plans yet to upgrade this.
 
-Here is the reason why: in your interface, you can search for one string, for example: "hello" and either this string corresponds to a known value in your database or not. This string is your "identifier" on the front-end that you'll pass to your backend to create a new item if this one doesn't exist yet. This will just work for small models, like :class:`Tag`s. A primary key, a name, and that's it. If the tag name you're typing in your search field is unknown, your backend will be able to perform a basic Django creation like this:
+Here is the reason why: in your interface, you can search for one string, for example: "hello" and either this string corresponds to a known value in your database or not. This string is your "identifier" on the front-end that you'll pass to your backend to create a new item if this one doesn't exist yet. This will just work for small models, like :class:`Tags <Tag>`. A primary key, a name, and that's it. If the tag name you're typing in your search field is unknown, your backend will be able to perform a basic Django creation like this:
 
 .. code-block:: python
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,33,34,35}-django{18,19},flake8
+envlist = py{27,33,34,35}-django{18,19},flake8,doclint
 
 [testenv]
 usedevelop = True
@@ -12,6 +12,7 @@ basepython =
     flake8: python2.7
     serve: python2.7
     docs: python2.7
+    doclint: python2.7
 deps =
     {env:TOX_EXTRA:}
     -rrequirements-test.pip
@@ -34,6 +35,13 @@ whitelist_externals =
     echo
 commands =
     echo "Skipped Tests: incompatible dependencies"
+
+[testenv:doclint]
+changedir = docs/
+deps = Sphinx
+whitelist_externals = make
+commands =
+    make clean html SPHINXOPTS='-W'
 
 # Please do not run this job in non-interactive (CI) mode!
 [testenv:serve]

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,7 @@ deps = Sphinx
 whitelist_externals = make
 commands =
     make clean html SPHINXOPTS='-W'
+    python doc_checker.py
 
 # Please do not run this job in non-interactive (CI) mode!
 [testenv:serve]


### PR DESCRIPTION
- [x] some literalincludes are out of scope
- [x] `fields-widgets.rst:73: WARNING: Inline interpreted text or phrase reference start-string without end-string.`
- [x] add a "doc check" job to travis
