### PR TITLE
Return the original HTTP error message to the front-end

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ master (unreleased)
 
 - Added a ``make clean`` command to remove junk assets (#64).
 - Added a ``doclint`` job to check documentation build (#69).
+- Return the eventual HTTP error message to the front-end in the context of a HTTP error in a ``AgnocompleteURLProxy`` field (#71).
 
 
 0.6.0 (2016-10-10)

--- a/demo/tests/test_url_proxy_views.py
+++ b/demo/tests/test_url_proxy_views.py
@@ -2,8 +2,16 @@ import json
 
 from django.test import TestCase
 from django.core.urlresolvers import reverse
+from django.utils.encoding import force_text as text
 
 from .. import DATABASE, GOODAUTHTOKEN
+from ..views_proxy import (
+    MESSAGE_400,
+    MESSAGE_403,
+    MESSAGE_404,
+    MESSAGE_405,
+    MESSAGE_500,
+)
 
 
 class UrlProxyGenericTest(object):
@@ -217,18 +225,28 @@ class UrlProxyErrorsTest(TestCase):
         response = self.client.get(
             reverse('url-proxy:errors'), {'q': '400'})
         self.assertEqual(response.status_code, 400)
+        self.assertEqual(text(response.content), MESSAGE_400)
 
     def test_403(self):
         response = self.client.get(
             reverse('url-proxy:errors'), {'q': '403'})
         self.assertEqual(response.status_code, 403)
+        self.assertEqual(text(response.content), MESSAGE_403)
 
     def test_404(self):
         response = self.client.get(
             reverse('url-proxy:errors'), {'q': '404'})
         self.assertEqual(response.status_code, 404)
+        self.assertEqual(text(response.content), MESSAGE_404)
+
+    def test_405(self):
+        response = self.client.get(
+            reverse('url-proxy:errors'), {'q': '405'})
+        self.assertEqual(response.status_code, 405)
+        self.assertEqual(text(response.content), MESSAGE_405)
 
     def test_500(self):
         response = self.client.get(
             reverse('url-proxy:errors'), {'q': 'whatever'})
         self.assertEqual(response.status_code, 500)
+        self.assertEqual(text(response.content), MESSAGE_500)

--- a/demo/views_proxy.py
+++ b/demo/views_proxy.py
@@ -142,6 +142,13 @@ def simple_post(request, *args, **kwargs):
     return HttpResponse(response)
 
 
+MESSAGE_400 = "I am a bad request"
+MESSAGE_403 = "You shall not pass"
+MESSAGE_404 = "I must have put it there, where is it?"
+MESSAGE_405 = "Can't touch this"
+MESSAGE_500 = "Server error, probably our fault"
+
+
 @require_GET
 def errors(request, *args, **kwargs):
     """
@@ -151,14 +158,14 @@ def errors(request, *args, **kwargs):
     """
     search_term = request.GET.get('q', None)
     if '400' in search_term:
-        return HttpResponseBadRequest()
+        return HttpResponseBadRequest(MESSAGE_400)
     elif '403' in search_term:
-        return HttpResponseForbidden()
+        return HttpResponseForbidden(MESSAGE_403)
     elif '404' in search_term:
-        return HttpResponseNotFound()
+        return HttpResponseNotFound(MESSAGE_404)
     elif '405' in search_term:
-        return HttpResponseNotAllowed()
-    return HttpResponseServerError()
+        return HttpResponseNotAllowed(['PATCH'], MESSAGE_405)
+    return HttpResponseServerError(MESSAGE_500)
 
 
 @require_GET


### PR DESCRIPTION
In case of a HTTP error thrown with a consistent message, return it to the error detail in the JSON description. of course, this should be optional, if you want to obfuscate the returned message and send back a standard message (but you may use the original error in your logs, that'd be cool).
