### PR TITLE
Display error to the front-end

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ master (unreleased)
 - Return the eventual HTTP error message to the front-end in the context of a HTTP error in a ``AgnocompleteURLProxy`` field (#71).
 - Link the Github project on the documentation homepage (#73).
 - Mention the version of `django-autocomplete-light` it reuses concepts from (#74).
+- In the "error" demo, display the error message returned by the Agnocomplete call (#65).
 
 
 0.6.0 (2016-10-10)

--- a/demo/static/js/demo/selectize.js
+++ b/demo/static/js/demo/selectize.js
@@ -1,4 +1,20 @@
 $(document).ready(function() {
+
+    function errorCallback(resp) {
+        $('.error').remove();
+        errors = resp.responseJSON.errors;
+        status = resp.status;
+        console.debug(status);
+        console.debug(errors);
+        content = '<div class="error">Error status code: ' + status;
+        content += '<ul>';
+        for (var i = 0; i < errors.length; i++) {
+            content += '<li>' + errors[i].title + ': ' + errors[i].detail + '</li>';
+        }
+        content += '<ul></div>';
+        $('#search-form').after(content);
+    }
+
     $('[data-agnocomplete]').each(function(index, select) {
 
         function getMaxItems() {
@@ -24,8 +40,8 @@ $(document).ready(function() {
                 $.ajax({
                     url: $(select).data('url') + '?q=' + encodeURIComponent(query),
                     type: 'GET',
-                    error: function() {
-                        callback();
+                    error: function(resp) {
+                        errorCallback(resp);
                     },
                     success: function(res) {
                         callback(res.data);

--- a/demo/templates/base.html
+++ b/demo/templates/base.html
@@ -19,7 +19,7 @@
         {% if form.help_text %}
         <p style="color: #444;">{{ form.help_text|safe|linebreaks }}</p>
         {% endif %}
-        <form action="." method="post">
+        <form action="." method="post" id="search-form">
             {{ form.as_p }}
             <p><input type="submit" value="OK">
         </form>

--- a/docs/doc_checker.py
+++ b/docs/doc_checker.py
@@ -33,7 +33,11 @@ if __name__ == '__main__':
     expected_html_files = get_expected_html_files(rootdir, files)
 
     # Manually fed:
-    html_files = ['admin-site.html', 'autocomplete-definition.html']
+    html_files = [
+        'admin-site.html',
+        'autocomplete-definition.html',
+        'error-handling.html',
+    ]
     # CHECK!
     files = copy(html_files)
     files = map(lambda item: "{}/{}".format("/_build/html", item), files)

--- a/docs/error-handling.rst
+++ b/docs/error-handling.rst
@@ -21,3 +21,13 @@ This error payload format is inspired by `JSON API <http://jsonapi.org/format/#e
 .. important::
 
     Along with this payload, the response status code may be a 4xx or a 5xx depending on the error raised.
+
+Display errors on the front-end side
+------------------------------------
+
+You may browse the ``selectize.js`` file, that shows an example on how to handle errors and use them in your user interface:
+
+.. literalinclude:: ../demo/static/js/demo/selectize.js
+    :language: javascript
+    :lines: 3-16
+    :dedent: 4


### PR DESCRIPTION
closes #65
- prints status and error objects in the console,
- display error messages in a DHTML div
- amend documentation with a literal example
