### PR TITLE
Handle to_field_name correctly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ master (unreleased)
 - Mention the version of `django-autocomplete-light` it reuses concepts from (#74).
 - In the "error" demo, display the error message returned by the Agnocomplete call (#65).
 - Update README (typos, syntax HL on commands) (#75).
+- Handle the ``to_field_name`` parameter with ``AgnocompleteModel`` and allow customization of the label alone by overriding ``AgnocompleteModel.label()`` (#77).
 
 
 0.6.0 (2016-10-10)

--- a/agnocomplete/__init__.py
+++ b/agnocomplete/__init__.py
@@ -37,4 +37,5 @@ def autodiscover():
                 logger.warning(ex)
                 raise ImportError(ex)
 
+
 default_app_config = 'agnocomplete.app.AgnocompleteConfig'

--- a/agnocomplete/fields.py
+++ b/agnocomplete/fields.py
@@ -67,6 +67,9 @@ class AgnocompleteMixin(object):
         # If not an instance, instanciate this
         if not isinstance(klass_or_instance, AgnocompleteBase):
             klass_or_instance = klass_or_instance(user=user)
+        # Pass the field when we have an AgnocompleteBase instance
+        if isinstance(klass_or_instance, AgnocompleteBase):
+            klass_or_instance.set_agnocomplete_field(self)
         # Store it in the instance
         self.agnocomplete = klass_or_instance
         self.agnocomplete.user = user

--- a/demo/autocomplete.py
+++ b/demo/autocomplete.py
@@ -76,14 +76,9 @@ class AutocompletePersonShort(AutocompletePerson):
 
 
 class AutocompletePersonLabel(AutocompletePerson):
-    def item(self, current_item):
-        label = {
-            'value': text(current_item.pk),
-            'label': u'{item} {mail}'.format(
-                item=text(current_item), mail=current_item.email)
-        }
-
-        return label
+    def label(self, current_item):
+        return u'{item} {mail}'.format(
+            item=text(current_item), mail=current_item.email)
 
 
 # Special: not integrated into the registry (yet)

--- a/demo/forms.py
+++ b/demo/forms.py
@@ -101,6 +101,11 @@ class PersonContextTagModelForm(UserContextFormMixin, forms.ModelForm):
         fields = '__all__'
 
 
+class PersonEmailSearchForm(forms.Form):
+    search_person = fields.AgnocompleteModelField(AutocompletePerson,
+                                                  to_field_name='email')
+
+
 class UrlProxyFormMixin(object):
     help_text = """
 We're not using the usual fixture here. Here's our "database":

--- a/demo/tests/test_form.py
+++ b/demo/tests/test_form.py
@@ -1,4 +1,4 @@
-from ..forms import SearchContextForm
+from ..forms import PersonEmailSearchForm, SearchContextForm
 from ..models import Person
 from . import LoaddataTestCase
 
@@ -37,4 +37,20 @@ class TestSearchContext(LoaddataTestCase):
             user=self.alice,
             data={'search_person': self.bob.pk},
         )
+        self.assertFalse(form.is_valid())
+
+
+class TestFieldName(LoaddataTestCase):
+
+    def setUp(self):
+        super(TestFieldName, self).setUp()
+        self.bob = Person.objects.get(email='bob@demo.com')
+
+    def test_valid(self):
+        form = PersonEmailSearchForm(data={'search_person': self.bob.email})
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data['search_person'], self.bob)
+
+    def test_invalid(self):
+        form = PersonEmailSearchForm(data={'search_person': self.bob.pk})
         self.assertFalse(form.is_valid())

--- a/docs/autocomplete-definition.rst
+++ b/docs/autocomplete-definition.rst
@@ -167,14 +167,9 @@ For example:
         fields = ['first_name', 'last_name']
         query_size_min = 2
 
-        def item(self, current_item):
-            label = {
-                'value': force_text(current_item.pk),
-                'label': u'{item} {mail}'.format(
-                    item=force_text(current_item), mail=current_item.email)
-            }
-
-            return label
+        def label(self, current_item):
+            return u'{item} {mail}'.format(
+                item=force_text(current_item), mail=current_item.email)
 
 
 Extract extra-information
@@ -197,18 +192,13 @@ You may want to add extra fields to your returned records, fields that belong to
             # This returns a dict of friends count, the keys being the PKs
             return count_friends([item.pk for item in queryset])
 
-        def item(self, current_item):
+        def label(self, current_item):
             friends = self.friends
-            label = {
-                'value': force_text(current_item.pk),
-                'label': u'{item} {mail} ({friends})'.format(
-                    item=force_text(current_item),
-                    mail=current_item.email,
-                    friends=friends.get(current_item.pk, 0)
-                )
-            }
-
-            return label
+            return u'{item} {mail} ({friends})'.format(
+                item=force_text(current_item),
+                mail=current_item.email,
+                friends=friends.get(current_item.pk, 0)
+            )
 
 
 .. important::
@@ -225,6 +215,17 @@ You may want to add extra fields to your returned records, fields that belong to
 
         queryset = self.final_raw_queryset.filter(field="something")
         queryset = queryset[:2]
+
+Using a different field for values
+----------------------------------
+
+As with a standard ``ModelChoiceField``, you may set the :attr:`to_field_name` attribute on ``AgnocompleteField`` to use a specific model field for form values instead of the primary key.  Be sure to use a unique field for the model.
+
+.. code-block:: python
+
+    class SearchForm(forms.Form):
+        search_person = fields.AgnocompleteField(
+            AutocompletePerson, to_field_name='email')
 
 Extra arguments
 ===============


### PR DESCRIPTION
This PR allows handling the `to_field_name` parameter correctly to use something other than `pk` as a value on `AgnocompleteModel`.

It also introduces a new `label()` method on `AgnocompleteModel` that is called by `item()`. Overriding it allows customizing item labels without interfering with how values are computed.