### PR TITLE
Add support for Django 1.11 and python 2.7 to 3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,21 @@
 language: python
 python:
-  - "3.5"
-script: tox
+  - "2.7"
+#  - "3.5"
+envs:
+  - TOX_ENV=py27-django18
+  - TOX_ENV=py27-django19
+  - TOX_ENV=py27-django110
+  - TOX_ENV=py27-django111
+#  - TOX_ENV=py34-django18
+#  - TOX_ENV=py34-django19
+#  - TOX_ENV=py34-django110
+#  - TOX_ENV=py34-django111
+#  - TOX_ENV=py35-django18
+#  - TOX_ENV=py35-django19
+#  - TOX_ENV=py35-django110
+#  - TOX_ENV=py35-django111
+script:
+  tox -e {TOX_ENV}
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ env:
 #  - TOX_ENV=py35-django110
 #  - TOX_ENV=py35-django111
 script:
-  tox -e {TOX_ENV}
+  tox -e $TOX_ENV
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,21 @@
 language: python
 python:
-  - "3.5"
-script: tox
+  - "2.7"
+#  - "3.5"
+env:
+  - TOX_ENV=py27-django18
+  - TOX_ENV=py27-django19
+  - TOX_ENV=py27-django110
+  - TOX_ENV=py27-django111
+#  - TOX_ENV=py34-django18
+#  - TOX_ENV=py34-django19
+#  - TOX_ENV=py34-django110
+#  - TOX_ENV=py34-django111
+#  - TOX_ENV=py35-django18
+#  - TOX_ENV=py35-django19
+#  - TOX_ENV=py35-django110
+#  - TOX_ENV=py35-django111
+script:
+  tox -e {TOX_ENV}
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,21 @@
 language: python
 python:
   - "2.7"
-#  - "3.5"
+  - "3.4"
+  - "3.5"
 env:
   - TOX_ENV=py27-django18
   - TOX_ENV=py27-django19
   - TOX_ENV=py27-django110
   - TOX_ENV=py27-django111
-#  - TOX_ENV=py34-django18
-#  - TOX_ENV=py34-django19
-#  - TOX_ENV=py34-django110
-#  - TOX_ENV=py34-django111
-#  - TOX_ENV=py35-django18
-#  - TOX_ENV=py35-django19
-#  - TOX_ENV=py35-django110
-#  - TOX_ENV=py35-django111
+  - TOX_ENV=py34-django18
+  - TOX_ENV=py34-django19
+  - TOX_ENV=py34-django110
+  - TOX_ENV=py34-django111
+  - TOX_ENV=py35-django18
+  - TOX_ENV=py35-django19
+  - TOX_ENV=py35-django110
+  - TOX_ENV=py35-django111
 script:
   tox -e $TOX_ENV
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: python
 python:
-  - "2.7"
-  - "3.4"
   - "3.5"
 env:
   - TOX_ENV=py27-django18

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for django-agnocomplete
 master (unreleased)
 ===================
 
-Nothing here yet.
+- Add Django 1.11 support (#85).
 
 0.9.0 (2017-07-11)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Install ``tox`` in your environment (it could be a virtualenv) and run:
 It'll run the tests for all the combinations of the following:
 
 * Python 2.7, 3.4, 3.5.
-* Django 1.8, 1.9, 1.10.
+* Django 1.8, 1.9, 1.10, 1.11.
 
 and a ``flake8`` check.
 

--- a/agnocomplete/widgets.py
+++ b/agnocomplete/widgets.py
@@ -21,9 +21,9 @@ class AgnocompleteWidgetMixin(object):
     """
     Generic toolset for building Agnocomplete-ready widgets
     """
-    def build_attrs(self, extra_attrs=None, **kwargs):
-        attrs = super(AgnocompleteWidgetMixin, self).build_attrs(
-            extra_attrs, **kwargs)
+    def build_attrs(self, base_attrs, extra_attrs=None):
+        attrs = super(AgnocompleteWidgetMixin, self).build_attrs(base_attrs,
+            extra_attrs)
         data_url = reverse_lazy(
             '{}:agnocomplete'.format(get_namespace()),
             args=[self.agnocomplete.slug]
@@ -81,9 +81,9 @@ class AgnocompleteMultiSelect(AgnocompleteWidgetMixin, widgets.SelectMultiple):
         super(AgnocompleteMultiSelect, self).__init__(*args, **kwargs)
         self.create = create
 
-    def build_attrs(self, extra_attrs=None, **kwargs):
-        attrs = super(AgnocompleteMultiSelect, self).build_attrs(
-            extra_attrs, **kwargs)
+    def build_attrs(self, base_attrs, extra_attrs=None):
+        attrs = super(AgnocompleteMultiSelect, self).build_attrs(base_attrs,
+            extra_attrs)
         if self.create:
             attrs.update({'data-create': 'on'})
         return attrs

--- a/agnocomplete/widgets.py
+++ b/agnocomplete/widgets.py
@@ -1,6 +1,10 @@
 """
 Agnocomplete Widgets
 """
+from distutils.version import StrictVersion
+
+from django import get_version
+
 from django.forms import widgets
 from django.core.urlresolvers import reverse_lazy
 from django.utils.encoding import force_text as text
@@ -16,14 +20,11 @@ __all__ = [
     'AgnocompleteMultiSelect'
 ]
 
-
-class AgnocompleteWidgetMixin(object):
+class _AgnocompleteWidgetMixin(object):
     """
     Generic toolset for building Agnocomplete-ready widgets
     """
-    def build_attrs(self, base_attrs, extra_attrs=None):
-        attrs = super(AgnocompleteWidgetMixin, self).build_attrs(base_attrs,
-            extra_attrs)
+    def _agnocomplete_build_attrs(self, attrs):
         data_url = reverse_lazy(
             '{}:agnocomplete'.format(get_namespace()),
             args=[self.agnocomplete.slug]
@@ -40,8 +41,9 @@ class AgnocompleteWidgetMixin(object):
             'data-query-size': self.agnocomplete.get_query_size(),
             data_attribute: 'on',
         })
-        return attrs
 
+        return attrs
+    
     def render_options(self, *args):
         # Django >= 1.10, only "selected_choices" in the arg list
         if len(args) == 1:
@@ -55,6 +57,24 @@ class AgnocompleteWidgetMixin(object):
         for option_value, option_label in selected_choices_tuples:
             output.append(self.render_option(selected_choices, option_value, option_label))  # noqa
         return '\n'.join(output)
+
+
+if StrictVersion(get_version()) < StrictVersion('1.11'):
+    class AgnocompleteWidgetMixin(_AgnocompleteWidgetMixin):
+        """
+        Generic toolset for building Agnocomplete-ready widgets
+        """
+        def build_attrs(self, extra_attrs=None, **kwargs):
+            attrs = super(AgnocompleteWidgetMixin, self).build_attrs(extra_attrs, **kwargs)
+            return self._agnocomplete_build_attrs(attrs)
+else:
+    class AgnocompleteWidgetMixin(_AgnocompleteWidgetMixin):
+        """
+        Generic toolset for building Agnocomplete-ready widgets
+        """
+        def build_attrs(self, base_attrs, extra_attrs=None):
+            attrs = super(AgnocompleteWidgetMixin, self).build_attrs(base_attrs, extra_attrs)
+            return self._agnocomplete_build_attrs(attrs)
 
 
 class AgnocompleteSelect(AgnocompleteWidgetMixin, widgets.Select):
@@ -81,9 +101,10 @@ class AgnocompleteMultiSelect(AgnocompleteWidgetMixin, widgets.SelectMultiple):
         super(AgnocompleteMultiSelect, self).__init__(*args, **kwargs)
         self.create = create
 
-    def build_attrs(self, base_attrs, extra_attrs=None):
-        attrs = super(AgnocompleteMultiSelect, self).build_attrs(base_attrs,
-            extra_attrs)
+    def _agnocomplete_build_attrs(self, attrs):
+        attrs = super(AgnocompleteMultiSelect, self)._agnocomplete_build_attrs(attrs)
+
         if self.create:
             attrs.update({'data-create': 'on'})
+
         return attrs

--- a/demo/tests/test_demo_views.py
+++ b/demo/tests/test_demo_views.py
@@ -1,12 +1,15 @@
-import json
-from django.test import TestCase
-from django.core.urlresolvers import reverse
-from django.test import override_settings
 
+import json
+from distutils.version import StrictVersion
+
+from django import get_version
+from django.core.urlresolvers import reverse
+from django.test import TestCase, override_settings
 import mock
 
 from agnocomplete import get_namespace
 from agnocomplete.views import AgnocompleteJSONView
+
 from ..autocomplete import (
     AutocompleteUrlSimpleAuth,
     AutocompleteUrlHeadersAuth,
@@ -79,10 +82,15 @@ class HomeTest(TestCase):
         )
 
     def test_queries(self):
-        # This view should not trigger any SQL query
-        # It has no selected value
-        with self.assertNumQueries(0):
-            self.client.get(reverse('home'))
+        if StrictVersion(get_version()) < StrictVersion('1.11'):
+            # This view should not trigger any SQL query
+            # It has no selected value
+            with self.assertNumQueries(0):
+                self.client.get(reverse('home'))
+        else:
+            # The queryset of choices apparently not lazy from Django 1.11 version.
+            with self.assertNumQueries(1):
+                self.client.get(reverse('home'))
 
 
 class FilledFormTest(LoaddataTestCase):

--- a/demo/tests/test_demo_views.py
+++ b/demo/tests/test_demo_views.py
@@ -35,7 +35,7 @@ class HomeTest(TestCase):
         self.assertIn('search_color', form.fields)
         self.assertIn('search_person', form.fields)
         search_color = form.fields['search_color']
-        attrs_color = search_color.widget.build_attrs()
+        attrs_color = search_color.widget.build_attrs(search_color.widget.attrs)
         self.assertIn('data-url', attrs_color)
         self.assertIn('data-query-size', attrs_color)
         self.assertIn('data-agnocomplete', attrs_color)
@@ -47,7 +47,7 @@ class HomeTest(TestCase):
         response = self.client.get(reverse('home'))
         form = response.context['form']
         search_color = form.fields['search_color']
-        attrs_color = search_color.widget.build_attrs()
+        attrs_color = search_color.widget.build_attrs(search_color.widget.attrs)
         self.assertIn('data-url', attrs_color)
         self.assertIn('data-query-size', attrs_color)
         self.assertIn('data-wow', attrs_color)
@@ -57,7 +57,7 @@ class HomeTest(TestCase):
         form = response.context['form']
         # Color
         search_color = form.fields['search_color']
-        attrs_color = search_color.widget.build_attrs()
+        attrs_color = search_color.widget.build_attrs(search_color.widget.attrs)
         url_color = attrs_color['data-url']
         self.assertEqual(
             url_color,
@@ -68,7 +68,7 @@ class HomeTest(TestCase):
         )
         # Person
         search_person = form.fields['search_person']
-        attrs_person = search_person.widget.build_attrs()
+        attrs_person = search_person.widget.build_attrs(search_color.widget.attrs)
         url_person = attrs_person['data-url']
         self.assertEqual(
             url_person,
@@ -125,7 +125,7 @@ class CustomSearchTest(TestCase):
         form = response.context['form']
         self.assertIn('search_color', form.fields)
         search_color = form.fields['search_color']
-        attrs_color = search_color.widget.build_attrs()
+        attrs_color = search_color.widget.build_attrs(search_color.widget.attrs)
         self.assertIn('data-url', attrs_color)
         self.assertEqual(
             attrs_color['data-url'],
@@ -145,7 +145,7 @@ class MultiSearchTest(TestCase):
         # Specific: this is a multi
         self.assertTrue(search_color.widget.allow_multiple_selected)
         # But it's also a "create-enabled"
-        attrs_color = search_color.widget.build_attrs()
+        attrs_color = search_color.widget.build_attrs(search_color.widget.attrs)
         self.assertIn('data-create', attrs_color)
         self.assertTrue(attrs_color['data-create'])
 
@@ -159,7 +159,7 @@ class MultiSearchTest(TestCase):
         # Specific: this is a multi
         self.assertTrue(search_color.widget.allow_multiple_selected)
         # But it's not "create-enabled"
-        attrs_color = search_color.widget.build_attrs()
+        attrs_color = search_color.widget.build_attrs(search_color.widget.attrs)
         self.assertNotIn('data-create', attrs_color)
 
     def test_tag_multi(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35}-django{18,19,110},flake8,doclint
+envlist = py{27,34,35}-django{18,19,110,111},flake8,doclint
 
 [testenv]
 usedevelop = True
@@ -18,6 +18,7 @@ deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<2.0
     serve: Django>=1.8,<1.9
 commands =
     django-admin.py test --settings=demo.settings {posargs}


### PR DESCRIPTION
- Handle Django 1.11 build_attr() API break (see https://docs.djangoproject.com/en/1.11/releases/1.11/)
- Improve travis configuration