### PR TITLE
Fix the multiple Model Field search with authentication behaviour

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ master (unreleased)
 ===================
 
 * Various Flake8 fixes (#89).
+* Fix the multiple Model Field search with authentication behaviour. Please note that this bug would only occur if ``Django<1.11`` (#91).
 
 0.10.0 (2018-01-10)
 ==================

--- a/demo/autocomplete.py
+++ b/demo/autocomplete.py
@@ -107,6 +107,19 @@ class AutocompletePersonDomain(AgnocompleteModel):
         return Person.objects.filter(email__endswith=domain)
 
 
+class AutocompletePersonDomainSpecial(AutocompletePersonDomain):
+    """
+    A special domain-related search
+
+    We'll do silly things in the "selected" method.
+    """
+    def selected(self, ids):
+        # Introducing a new variable here, to make sure the
+        # "account_registrations" property is able to fetch the matricules.
+        self._selected_queryset = self.get_queryset()
+        return super(AutocompletePersonDomainSpecial, self).selected(ids)
+
+
 # Do not register this, it's for custom view demo
 class HiddenAutocomplete(AutocompleteColor):
     query_size_min = 2
@@ -254,6 +267,7 @@ register(AutocompletePersonShort)
 register(AutocompleteChoicesPages)
 register(AutocompleteChoicesPagesOverride)
 register(AutocompletePersonDomain)
+register(AutocompletePersonDomainSpecial)
 register(AutocompleteCustomUrl)
 register(AutocompleteTag)
 register(AutocompleteContextTag)

--- a/demo/forms.py
+++ b/demo/forms.py
@@ -49,6 +49,10 @@ class SearchFormTextInput(forms.Form):
 
 class SearchContextForm(UserContextFormMixin, forms.Form):
     search_person = fields.AgnocompleteModelField('AutocompletePersonDomain')
+    search_person_multiple = fields.AgnocompleteModelMultipleField(
+        'AutocompletePersonDomainSpecial',
+        required=False
+    )
 
 
 class SearchCustom(forms.Form):

--- a/demo/tests/__init__.py
+++ b/demo/tests/__init__.py
@@ -34,7 +34,7 @@ class LoaddataLiveTestCase(LoaddataMixin, LiveServerTestCase):
 class RegistryTestGeneric(LoaddataTestCase):
 
     def _test_registry_keys(self, keys):
-        self.assertEqual(len(keys), 22)
+        self.assertEqual(len(keys), 23)
         self.assertIn("AutocompleteColor", keys)
         self.assertIn("AutocompleteColorExtra", keys)
         self.assertIn("AutocompletePerson", keys)
@@ -43,6 +43,7 @@ class RegistryTestGeneric(LoaddataTestCase):
         self.assertIn("AutocompleteChoicesPages", keys)
         self.assertIn("AutocompleteChoicesPagesOverride", keys)
         self.assertIn("AutocompletePersonDomain", keys)
+        self.assertIn("AutocompletePersonDomainSpecial", keys)
         self.assertIn("AutocompleteTag", keys)
         # Multiselect
         self.assertIn("AutocompleteColorShort", keys)

--- a/demo/tests/test_views.py
+++ b/demo/tests/test_views.py
@@ -176,6 +176,10 @@ class SearchContextFormTest(AutocompleteViewTestGeneric,
         self.assertTrue(data)
 
 
+class SearchContextFormMultipleTest(SearchContextFormTest):
+    view_key = 'AutocompletePersonDomainSpecial'
+
+
 class CustomizedViewsTest(RegistryTestGeneric):
 
     @property


### PR DESCRIPTION
Please note that this implementation will be obsolete when reaching Django 1.11, that removes the ``Select.render_options()`` method.

This was the method that called the ``selected()`` method, that eventually needed the authentication context to be loaded.

ref: https://docs.djangoproject.com/en/2.0/releases/1.11/#changes-due-to-the-introduction-of-template-based-widget-rendering

The failing test is simulating the following erroneous behaviour:

* A form using a ``AgnocompleteModelMultipleField`` field,
* This field is pointing at an agncomplete class with a special `selected()` method. In this method we're calling `get_queryset()`. At this point of the code, the user context hasn't been transmitted to the Agncomplete class.
    
The problem is that this behaviour is well implemented in the "mono-Model" Agncomplete class, but was skipped in the Multiple Model search classes.
