### PR TITLE
Drop obsolete versions of Django

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,8 @@ language: python
 python:
   - "3.5"
 env:
-  - TOX_ENV=py27-django18
-  - TOX_ENV=py27-django19
-  - TOX_ENV=py27-django110
   - TOX_ENV=py27-django111
-  - TOX_ENV=py34-django18
-  - TOX_ENV=py34-django19
-  - TOX_ENV=py34-django110
   - TOX_ENV=py34-django111
-  - TOX_ENV=py35-django18
-  - TOX_ENV=py35-django19
-  - TOX_ENV=py35-django110
   - TOX_ENV=py35-django111
   - TOX_ENV=flake8
   - TOX_ENV=doclint

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ master (unreleased)
 
 * Added ``doclint`` & ``flake8`` to travis builds (#99).
 * Fixed numerous flake8 errors (#99).
+* Dropped support for Django 1.8, 1.9, 1.10 (#98).
 
 0.12.2 (2018-03-09)
 ===================

--- a/README.rst
+++ b/README.rst
@@ -47,13 +47,9 @@ Install ``tox`` in your environment (it could be a virtualenv) and run:
 It'll run the tests for all the combinations of the following:
 
 * Python 2.7, 3.4, 3.5.
-* Django 1.8, 1.9, 1.10, 1.11.
+* Django 1.11.
 
 and a ``flake8`` check.
-
-.. note::
-
-    The combination Python 3.3 and Django 1.9 is incompatible - `see Django 1.9 release notes <https://docs.djangoproject.com/en/1.10/releases/1.9/>`_
 
 Are you a developer?
 --------------------
@@ -62,7 +58,7 @@ To target a specific test case, use the following:
 
 .. code:: sh
 
-    $ tox -e py27-django18 --  demo.tests.test_core.AutocompleteChoicesPagesOverrideTest
+    $ tox -e py27-django110 --  demo.tests.test_core.AutocompleteChoicesPagesOverrideTest
 
 Everything after the double-dash will be passed to the django-admin.py test command.
 
@@ -70,7 +66,7 @@ If you need to install a debugger (let's say `ipdb`), you can use the ``TOX_EXTR
 
 .. code:: sh
 
-    $ TOX_EXTRA=ipdb tox -e py27-django18
+    $ TOX_EXTRA=ipdb tox -e py27-django110
 
 .. note::
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35}-django{18,19,110,111},flake8,doclint
+envlist = py{27,34,35}-django{111},flake8,doclint
 
 [testenv]
 usedevelop = True
@@ -15,9 +15,6 @@ basepython =
 deps =
     {env:TOX_EXTRA:}
     -rrequirements-test.pip
-    django18: Django>=1.8,<1.9
-    django19: Django>=1.9,<1.10
-    django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2.0
     serve: Django>=1.8,<1.9
 commands =


### PR DESCRIPTION
- [x] Drop Django 1.8
- [x] Drop Django 1.9
- [x] Drop Django 1.10

ref: https://www.djangoproject.com/download/#supported-versions