### PR TITLE
Add a way to skip item 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for django-agnocomplete
 master (unreleased)
 ==================
 
-Nothing here yet
+* Add a way in UrlProxy widget to filter value with python (#104)
 
 0.13.0 (2018-10-02)
 ===================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ master (unreleased)
 ==================
 
 * Add a way in UrlProxy widget to filter value with python (#104)
+* Provide a FieldMixin in order to use with UrlProxy Autocomplete for efficient value validation (#107)
 
 0.13.0 (2018-10-02)
 ===================

--- a/agnocomplete/core.py
+++ b/agnocomplete/core.py
@@ -17,7 +17,7 @@ from .constants import AGNOCOMPLETE_MIN_PAGESIZE
 from .constants import AGNOCOMPLETE_MAX_PAGESIZE
 from .constants import AGNOCOMPLETE_DEFAULT_QUERYSIZE
 from .constants import AGNOCOMPLETE_MIN_QUERYSIZE
-from .exceptions import AuthenticationRequiredAgnocompleteException
+from .exceptions import AuthenticationRequiredAgnocompleteException, SkipItem
 
 
 logger = logging.getLogger(__name__)
@@ -618,7 +618,10 @@ class AgnocompleteUrlProxy(with_metaclass(ABCMeta, AgnocompleteBase)):
         result = []
         for item in http_result:
             # Eventual result reshaping.
-            result.append(self.item(item))
+            try:
+                result.append(self.item(item))
+            except SkipItem:
+                continue
         return result
 
     def selected(self, ids):

--- a/agnocomplete/core.py
+++ b/agnocomplete/core.py
@@ -17,7 +17,9 @@ from .constants import AGNOCOMPLETE_MIN_PAGESIZE
 from .constants import AGNOCOMPLETE_MAX_PAGESIZE
 from .constants import AGNOCOMPLETE_DEFAULT_QUERYSIZE
 from .constants import AGNOCOMPLETE_MIN_QUERYSIZE
-from .exceptions import AuthenticationRequiredAgnocompleteException, SkipItem
+from .exceptions import AuthenticationRequiredAgnocompleteException
+from .exceptions import SkipItem
+from .exceptions import ItemNotFound
 
 
 logger = logging.getLogger(__name__)
@@ -641,3 +643,27 @@ class AgnocompleteUrlProxy(with_metaclass(ABCMeta, AgnocompleteBase)):
                             )
                         )
         return data
+
+    def validate(self, value):
+        """
+        From a value available on the remote server, the method returns the
+        complete item matching the value.
+        If case the value is not available on the server side or filtered
+        through :meth:`item`, the class:`agnocomplete.exceptions.ItemNotFound`
+        is raised.
+        """
+
+        url = self.get_item_url(value)
+        try:
+            data = self.http_call(url=url)
+        except requests.HTTPError:
+            raise ItemNotFound()
+
+        data = self.get_http_result(data)
+
+        try:
+            self.item(data)
+        except SkipItem:
+            raise ItemNotFound()
+
+        return value

--- a/agnocomplete/exceptions.py
+++ b/agnocomplete/exceptions.py
@@ -37,3 +37,10 @@ class SkipItem(Exception):
     Occurs when Item has to be skipped when building the final Payload
     """
     pass
+
+
+class ItemNotFound(Exception):
+    """
+    Occurs while searching an unexisting item on autocomplete choices.
+    """
+    pass

--- a/agnocomplete/exceptions.py
+++ b/agnocomplete/exceptions.py
@@ -30,3 +30,10 @@ class HTTPError(HTTPError):
     Occurs when the 3rd party API returns an error code
     """
     pass
+
+
+class SkipItem(Exception):
+    """
+    Occurs when Item has to be skipped when building the final Payload
+    """
+    pass

--- a/agnocomplete/fields.py
+++ b/agnocomplete/fields.py
@@ -10,6 +10,7 @@ from .core import AgnocompleteBase
 from .constants import AGNOCOMPLETE_USER_ATTRIBUTE
 from .widgets import AgnocompleteSelect, AgnocompleteMultiSelect
 from .register import get_agnocomplete_registry
+from .exceptions import ItemNotFound
 from .exceptions import UnregisteredAgnocompleteException
 
 
@@ -246,3 +247,19 @@ class AgnocompleteModelMultipleField(AgnocompleteContextQuerysetMixin,
         qs = super(AgnocompleteModelMultipleField, self).clean(pks)
 
         return qs
+
+
+class AgnocompleteUrlProxyMixin(object):
+    """
+    This mixin can be used with a field which actually using
+    :class:`agnocomplete.core.AutocompletUrlProxy`. The main purpose is to
+    provide a mechanism to validate the value through the Autocomplete.
+    """
+
+    def valid_value(self, value):
+        try:
+            self.agnocomplete.validate(value)
+        except ItemNotFound:
+            return False
+
+        return True

--- a/demo/autocomplete.py
+++ b/demo/autocomplete.py
@@ -12,6 +12,8 @@ from agnocomplete.core import (
     AgnocompleteModel,
     AgnocompleteUrlProxy,
 )
+from agnocomplete.exceptions import SkipItem
+
 from .models import Person, Tag, ContextTag
 from .common import COLORS
 from . import GOODAUTHTOKEN
@@ -257,6 +259,14 @@ class AutocompleteUrlSimpleWithExtra(AutocompleteUrlSimple):
         return super(AutocompleteUrlSimple, self).items(query, **kwargs)
 
 
+class AutocompleteUrlSkipItem(AutocompleteUrlSimple):
+
+    def item(self, obj):
+        if obj['label'] == 'first person':
+            raise SkipItem
+        return super(AutocompleteUrlSkipItem, self).item(obj)
+
+
 # Registration
 register(AutocompleteColor)
 register(AutocompleteColorExtra)
@@ -282,3 +292,4 @@ register(AutocompleteUrlHeadersAuth)
 register(AutocompleteUrlSimplePost)
 register(AutocompleteUrlErrors)
 register(AutocompleteUrlSimpleWithExtra)
+register(AutocompleteUrlSkipItem)

--- a/demo/autocomplete.py
+++ b/demo/autocomplete.py
@@ -6,13 +6,13 @@ from django.urls import reverse_lazy
 from django.utils.encoding import force_text as text
 from django.conf import settings
 
+from agnocomplete.exceptions import SkipItem
 from agnocomplete.register import register
 from agnocomplete.core import (
     AgnocompleteChoices,
     AgnocompleteModel,
     AgnocompleteUrlProxy,
 )
-from agnocomplete.exceptions import SkipItem
 
 from .models import Person, Tag, ContextTag
 from .common import COLORS
@@ -261,10 +261,18 @@ class AutocompleteUrlSimpleWithExtra(AutocompleteUrlSimple):
 
 class AutocompleteUrlSkipItem(AutocompleteUrlSimple):
 
+    data_key = 'data'
+
     def item(self, obj):
         if obj['label'] == 'first person':
             raise SkipItem
         return super(AutocompleteUrlSkipItem, self).item(obj)
+
+    def get_item_url(self, pk):
+        return '{}{}'.format(
+            getattr(settings, 'HTTP_HOST', ''),
+            reverse_lazy('url-proxy:atomic-item', args=[pk])
+        )
 
 
 # Registration

--- a/demo/fields.py
+++ b/demo/fields.py
@@ -30,3 +30,10 @@ class ModelMultipleObjectsField(fields.AgnocompleteModelMultipleField):
         Return the created model instance.
         """
         return self.queryset.model.objects.create(**kwargs)
+
+
+class AgnocompleteUrlProxyField(fields.AgnocompleteUrlProxyMixin,
+                                fields.AgnocompleteField):
+    """
+    Demo Field to use AutocompleteUrlProxy
+    """

--- a/demo/tests/__init__.py
+++ b/demo/tests/__init__.py
@@ -34,7 +34,7 @@ class LoaddataLiveTestCase(LoaddataMixin, LiveServerTestCase):
 class RegistryTestGeneric(LoaddataTestCase):
 
     def _test_registry_keys(self, keys):
-        self.assertEqual(len(keys), 23)
+        self.assertEqual(len(keys), 24)
         self.assertIn("AutocompleteColor", keys)
         self.assertIn("AutocompleteColorExtra", keys)
         self.assertIn("AutocompletePerson", keys)
@@ -64,6 +64,7 @@ class RegistryTestGeneric(LoaddataTestCase):
         self.assertIn("AutocompleteUrlHeadersAuth", keys)
         self.assertIn("AutocompleteUrlErrors", keys)
         self.assertIn("AutocompleteUrlSimpleWithExtra", keys)
+        self.assertIn("AutocompleteUrlSkipItem", keys)
 
 
 class MockRequestUser(object):

--- a/demo/tests/test_url_proxy.py
+++ b/demo/tests/test_url_proxy.py
@@ -19,6 +19,7 @@ from ..autocomplete import (
     AutocompleteUrlHeadersAuth,
     AutocompleteUrlSimplePost,
     AutocompleteUrlSimpleWithExtra,
+    AutocompleteUrlSkipItem,
 )
 from .. import DATABASE, GOODAUTHTOKEN
 RESULT_DICT = [{'value': text(item['pk']), 'label': text(item['name'])} for item in DATABASE]  # noqa
@@ -291,3 +292,26 @@ class AutocompleteUrlWithExtraTest(LiveServerTestCase):
                 {'value': 'moo', 'label': 'moo'}
             ]
         )
+
+
+@override_settings(HTTP_HOST='')
+class AutocompleteUrlSkipItemTest(LiveServerTestCase):
+    def test_search(self):
+        instance = AutocompleteUrlSkipItem()
+        # "mock" Change URL by adding the host
+        search_url = instance.search_url
+        with mock.patch('demo.autocomplete.AutocompleteUrlSkipItem'
+                        '.get_search_url') as mock_auto:
+            mock_auto.return_value = self.live_server_url + search_url
+            search_result = instance.items(query='person')
+            self.assertEqual(
+                list(search_result),
+                [
+                    {"value": '2', 'label': 'second person'},
+                    {"value": '3', 'label': 'third person'},
+                    {"value": '4', 'label': 'fourth person'},
+                    {"value": '5', 'label': 'fifth person'},
+                    {"value": '6', 'label': 'sixth person'},
+                    {"value": '7', 'label': 'seventh person'}
+                ],
+            )

--- a/demo/urls_proxy.py
+++ b/demo/urls_proxy.py
@@ -7,6 +7,8 @@ from . import views_proxy
 
 urlpatterns = [
     url(r'^item/(?P<pk>[0-9]+)$', views_proxy.item, name='item'),
+    url(r'^atomicitem/(?P<pk>[0-9]+)$', views_proxy.atomic_item,
+        name='atomic-item'),
     url(r'^simple/$', views_proxy.simple, name='simple'),
     url(r'^simple-post/$', views_proxy.simple_post, name='simple-post'),
     url(r'^convert/$', views_proxy.convert, name='convert'),

--- a/demo/views_proxy.py
+++ b/demo/views_proxy.py
@@ -180,3 +180,22 @@ def item(request, pk):
     response = json.dumps(result)
     logger.debug('response: `%s`', response)
     return HttpResponse(response)
+
+
+@require_GET
+def atomic_item(request, pk):
+    """
+    Similar to `item` but does not return a list
+    """
+    data = None
+    for item in DATABASE:
+        if text(item['pk']) == text(pk):
+            data = convert_data(item)
+            break
+    if not data:
+        raise Http404("Unknown item `{}`".format(pk))
+    logger.debug('3rd item search: `%s`', pk)
+    result = {'data': data}
+    response = json.dumps(result)
+    logger.debug('response: `%s`', response)
+    return HttpResponse(response)

--- a/docs/url-proxy.rst
+++ b/docs/url-proxy.rst
@@ -104,6 +104,28 @@ or, if things are going more complicated:
                 label='{} {}'.format(current_item['label1'], current_item['label2']),
             )
 
+
+If you need to skip fields
+++++++++++++++++++++++++++
+
+
+Sometimes, passing in a query may not provide sufficient filtering to meet requirements. In such cases, :class:`agnocomplete.exceptions.SkipItem` can be raised to prevent a given item from appearing in the final result. Please note, however, that this is not a very efficient approach, and so should only be used as a last resort. It is generally preferable to apply ``server-side`` filtering if at all possible.
+
+.. code-block:: python
+
+    from agnocomplete.exceptions import SkipItem
+
+    class AutocompleteUrlConvert(AgnocompleteUrlProxy):
+
+        def item(self, current_item):
+            if not current_item['meta'].get('is_required'):
+                raise SkipItem()
+
+            return dict(
+                value=current_item[current_item['meta']['value_field']],
+                label='{} {}'.format(current_item['label1'], current_item['label2']),
+            )
+
 If the result doesn't follow standard schema
 ++++++++++++++++++++++++++++++++++++++++++++
 


### PR DESCRIPTION
For the AutocompleteProxyUrl, add a way to remove item from the final
payload. The `items` catchs a new Exception `SkipItem` and continue to
build the final result. The new exception is expected to be raised from
the `item` method.