### PR TITLE
Attempt to make it installable with Django 3.X serie

### DIFF
--- a/agnocomplete/urls.py
+++ b/agnocomplete/urls.py
@@ -1,13 +1,13 @@
 """
 Agnostic Autocomplete URLS
 """
-from django.conf.urls import url
+from django.conf.urls import re_path
 from .views import AgnocompleteView, CatalogView
 
 urlpatterns = [
-    url(
+    re_path(
         r'^(?P<klass>[-_\w]+)/$',
         AgnocompleteView.as_view(),
         name='agnocomplete'),
-    url(r'^$', CatalogView.as_view(), name='catalog'),
+    re_path(r'^$', CatalogView.as_view(), name='catalog'),
 ]

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author='PeopleDoc Inc.',
     license='MIT',
     install_requires=[
-        'Django>=2.2,<3.0',
+        'Django>=2.2,<4.0',
         'six',
         'requests',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,39}-django22,
+    py{36,37,38,39}-django{22,32},
     flake8,doclint
 
 [testenv]
@@ -20,6 +20,7 @@ deps =
     -rrequirements-test.pip
     # Keeping it here, because we'll probably widen our Django version tests.
     django22: Django>=2.2,<3.0
+    django32: Django>=3.2,<4.0
     serve: Django>=2.2,<3.0
 commands =
     python -Wd {envbindir}/coverage run --branch --source=agnocomplete {envbindir}/django-admin test --settings=demo.settings {posargs}


### PR DESCRIPTION
Maybe a bit naive, but:

- works with uMap running Django 3.2
- django-agnocomplete tests passe

I'm not in Django stuffs since a long time, so I may be missing something, but here is a starting point :)

fix https://github.com/peopledoc/django-agnocomplete/issues/119