### PR TITLE
Fix `path` warnings

### DIFF
--- a/agnocomplete/urls.py
+++ b/agnocomplete/urls.py
@@ -5,9 +5,6 @@ from django.urls import path
 from .views import AgnocompleteView, CatalogView
 
 urlpatterns = [
-    path(
-        r'^(?P<klass>[-_\w]+)/$',
-        AgnocompleteView.as_view(),
-        name='agnocomplete'),
-    path(r'^$', CatalogView.as_view(), name='catalog'),
+    path('<klass>/', AgnocompleteView.as_view(), name='agnocomplete'),
+    path('', CatalogView.as_view(), name='catalog'),
 ]


### PR DESCRIPTION
This pr should fix warnings (first two lines)

<img width="1792" alt="Screenshot 2022-02-04 at 13 16 49" src="https://user-images.githubusercontent.com/29764130/152520738-df3952bc-9eab-4f13-b92c-be08fd733806.png">
